### PR TITLE
Show users on overview

### DIFF
--- a/app/src/androidTest/java/com/swent/suddenbump/ui/overview/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/overview/OverviewScreenTest.kt
@@ -1,0 +1,59 @@
+package com.swent.suddenbump.ui.overview
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.swent.suddenbump.ui.navigation.NavigationActions
+import com.swent.suddenbump.ui.navigation.Route
+import com.swent.suddenbump.ui.navigation.Screen
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.verify
+
+class OverviewScreenTest {
+  private lateinit var navigationActions: NavigationActions
+  @get:Rule val composeTestRule = createComposeRule()
+
+  @Before
+  fun setUp() {
+    navigationActions = mock(NavigationActions::class.java)
+
+    `when`(navigationActions.currentRoute()).thenReturn(Route.OVERVIEW)
+    composeTestRule.setContent { OverviewScreen(navigationActions) }
+  }
+
+  @Test
+  fun hasRequiredComponents() {
+    composeTestRule.onNodeWithTag("overviewScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("settingsFab").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("addContactFab").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("appName").assertIsDisplayed()
+  }
+
+  @Test
+  fun settingsButtonCallsNavActions() {
+    composeTestRule.onNodeWithTag("overviewScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("settingsFab").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("settingsFab").performClick()
+    verify(navigationActions).navigateTo(screen = Screen.SETTINGS)
+  }
+
+  @Test
+  fun addContactButtonCallsNavActions() {
+    composeTestRule.onNodeWithTag("overviewScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("addContactFab").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("addContactFab").performClick()
+    verify(navigationActions).navigateTo(screen = Screen.ADD_CONTACT)
+  }
+
+  @Test
+  fun userListIsDisplayed() {
+    composeTestRule.onNodeWithTag("overviewScreen").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("userList").assertIsDisplayed()
+  }
+}

--- a/app/src/main/java/com/swent/suddenbump/MainActivity.kt
+++ b/app/src/main/java/com/swent/suddenbump/MainActivity.kt
@@ -38,8 +38,8 @@ import com.swent.suddenbump.ui.navigation.Screen
 import com.swent.suddenbump.ui.overview.AddContactScreen
 import com.swent.suddenbump.ui.overview.ConversationScreen
 import com.swent.suddenbump.ui.overview.OverviewScreen
-import com.swent.suddenbump.ui.profile.ContactScreen
 import com.swent.suddenbump.ui.overview.SettingsScreen
+import com.swent.suddenbump.ui.profile.ContactScreen
 import com.swent.suddenbump.ui.theme.SampleAppTheme
 
 class MainActivity : ComponentActivity() {

--- a/app/src/main/java/com/swent/suddenbump/MainActivity.kt
+++ b/app/src/main/java/com/swent/suddenbump/MainActivity.kt
@@ -39,7 +39,7 @@ import com.swent.suddenbump.ui.overview.AddContactScreen
 import com.swent.suddenbump.ui.overview.ConversationScreen
 import com.swent.suddenbump.ui.overview.OverviewScreen
 import com.swent.suddenbump.ui.profile.ContactScreen
-import com.swent.suddenbump.ui.settings.SettingsScreen
+import com.swent.suddenbump.ui.overview.SettingsScreen
 import com.swent.suddenbump.ui.theme.SampleAppTheme
 
 class MainActivity : ComponentActivity() {

--- a/app/src/main/java/com/swent/suddenbump/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/navigation/NavigationActions.kt
@@ -34,7 +34,7 @@ object TopLevelDestinations {
       TopLevelDestination(
           route = Route.MESS, icon = Icons.Outlined.MailOutline, textId = "Messages")
   val OVERVIEW =
-    TopLevelDestination(route = Route.OVERVIEW, icon = Icons.Outlined.Menu, textId = "Overview")
+      TopLevelDestination(route = Route.OVERVIEW, icon = Icons.Outlined.Menu, textId = "Overview")
   val MAP = TopLevelDestination(route = Route.MAP, icon = Icons.Outlined.Place, textId = "Map")
 }
 

--- a/app/src/main/java/com/swent/suddenbump/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/navigation/NavigationActions.kt
@@ -30,16 +30,16 @@ object Screen {
 data class TopLevelDestination(val route: String, val icon: ImageVector, val textId: String)
 
 object TopLevelDestinations {
-  val OVERVIEW =
-      TopLevelDestination(route = Route.OVERVIEW, icon = Icons.Outlined.Menu, textId = "Overview")
   val MESSAGES =
       TopLevelDestination(
           route = Route.MESS, icon = Icons.Outlined.MailOutline, textId = "Messages")
+  val OVERVIEW =
+    TopLevelDestination(route = Route.OVERVIEW, icon = Icons.Outlined.Menu, textId = "Overview")
   val MAP = TopLevelDestination(route = Route.MAP, icon = Icons.Outlined.Place, textId = "Map")
 }
 
 val LIST_TOP_LEVEL_DESTINATION =
-    listOf(TopLevelDestinations.OVERVIEW, TopLevelDestinations.MESSAGES, TopLevelDestinations.MAP)
+    listOf(TopLevelDestinations.MESSAGES, TopLevelDestinations.OVERVIEW, TopLevelDestinations.MAP)
 
 open class NavigationActions(
     private val navController: NavHostController,

--- a/app/src/main/java/com/swent/suddenbump/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/navigation/NavigationActions.kt
@@ -58,7 +58,7 @@ open class NavigationActions(
       // avoid building up a large stack of destinations
       popUpTo(navController.graph.findStartDestination().id) {
         saveState = true
-        // inclusive = true
+        inclusive = true
       }
 
       // Avoid multiple copies of the same destination when reselecting same item

--- a/app/src/main/java/com/swent/suddenbump/ui/overview/AddContact.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/overview/AddContact.kt
@@ -67,7 +67,7 @@ fun UserCard(user: User, navigationActions: NavigationActions) {
 }
 
 fun generateMockUsers(): List<User> {
-    val relativeDistances = listOf(5, 5, 5, 5, 10, 10, 10, 15, 15, 15)
+  val relativeDistances = listOf(5, 5, 5, 5, 10, 10, 10, 15, 15, 15)
   val firstNames =
       listOf("John", "Jane", "Alice", "Bob", "Charlie", "David", "Eve", "Frank", "Grace", "Hank")
   val lastNames =
@@ -96,7 +96,7 @@ fun generateMockUsers(): List<User> {
           "25 Novembre 1960")
 
   return (1..20).map { index ->
-      val relativeDist = relativeDistances[index % relativeDistances.size]
+    val relativeDist = relativeDistances[index % relativeDistances.size]
     val firstName = firstNames[index % firstNames.size]
     val lastName = lastNames[index % lastNames.size]
     User(

--- a/app/src/main/java/com/swent/suddenbump/ui/overview/AddContact.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/overview/AddContact.kt
@@ -40,6 +40,7 @@ data class User(
     val birthDate: String,
     val mail: String,
     val phoneNumber: String,
+    val relativeDist: Int,
 )
 
 @Composable
@@ -66,6 +67,7 @@ fun UserCard(user: User, navigationActions: NavigationActions) {
 }
 
 fun generateMockUsers(): List<User> {
+    val relativeDistances = listOf(5, 5, 5, 5, 10, 10, 10, 15, 15, 15)
   val firstNames =
       listOf("John", "Jane", "Alice", "Bob", "Charlie", "David", "Eve", "Frank", "Grace", "Hank")
   val lastNames =
@@ -94,6 +96,7 @@ fun generateMockUsers(): List<User> {
           "25 Novembre 1960")
 
   return (1..20).map { index ->
+      val relativeDist = relativeDistances[index % relativeDistances.size]
     val firstName = firstNames[index % firstNames.size]
     val lastName = lastNames[index % lastNames.size]
     User(
@@ -103,7 +106,8 @@ fun generateMockUsers(): List<User> {
         profilePictureUrl = "https://api.dicebear.com/9.x/lorelei/png?seed=${firstName}${lastName}",
         birthDate = birthDates[index % birthDates.size],
         mail = "${firstName.lowercase()}.${lastName.lowercase()}@example.com",
-        phoneNumber = "123-456-78${index.toString().padStart(2, '0')}")
+        phoneNumber = "123-456-78${index.toString().padStart(2, '0')}",
+        relativeDist = relativeDist)
   }
 }
 

--- a/app/src/main/java/com/swent/suddenbump/ui/overview/Overview.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/overview/Overview.kt
@@ -18,13 +18,17 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.compose.rememberNavController
 import com.swent.suddenbump.ui.navigation.BottomNavigationMenu
 import com.swent.suddenbump.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.swent.suddenbump.ui.navigation.NavigationActions
 import com.swent.suddenbump.ui.navigation.Screen
+import com.swent.suddenbump.ui.theme.violetColor
 
 
 @Composable
@@ -41,6 +45,17 @@ fun OverviewScreen(navigationActions: NavigationActions) {
                   modifier = Modifier.testTag("SettingsFab")) {
                     Icon(imageVector = Icons.Default.Settings, contentDescription = "Settings")
                   }
+            Text(
+                modifier = Modifier.testTag("appName").weight(1f),
+                text = "SuddenBump!",
+                style =
+                MaterialTheme.typography.headlineMedium.copy(
+                    fontSize = 30.sp,
+                    lineHeight = 44.sp),
+                color = violetColor,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center)
+            
               FloatingActionButton(
                   onClick = { navigationActions.navigateTo(Screen.ADD_CONTACT) },
                   modifier = Modifier.testTag("AddContactFab")) {
@@ -59,6 +74,7 @@ fun OverviewScreen(navigationActions: NavigationActions) {
       },
       content = { pd ->  Column(
           modifier = Modifier.padding(pd), horizontalAlignment = Alignment.CenterHorizontally) {
+
           if (mockUsers.isNotEmpty()) {
               LazyColumn { var currentDist: Int? = null
                   mockUsers.forEach { user ->

--- a/app/src/main/java/com/swent/suddenbump/ui/overview/Overview.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/overview/Overview.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Settings
@@ -15,7 +14,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -81,7 +79,11 @@ fun OverviewScreen(navigationActions: NavigationActions) {
                       }
                   } }
           } else {
-              Text(text = "Looks like no friends are nearby")
+              Text(text = "Looks like no friends are nearby",
+                  modifier = Modifier
+                      .fillMaxWidth()
+                      .padding(vertical = 8.dp),
+                  style = MaterialTheme.typography.titleLarge)
           }
       } })
 }

--- a/app/src/main/java/com/swent/suddenbump/ui/overview/Overview.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/overview/Overview.kt
@@ -30,10 +30,9 @@ import com.swent.suddenbump.ui.navigation.NavigationActions
 import com.swent.suddenbump.ui.navigation.Screen
 import com.swent.suddenbump.ui.theme.violetColor
 
-
 @Composable
 fun OverviewScreen(navigationActions: NavigationActions) {
-    val mockUsers = generateMockUsers().sortedBy { it.relativeDist }
+  val mockUsers = generateMockUsers().sortedBy { it.relativeDist }
 
   Scaffold(
       topBar = {
@@ -42,23 +41,22 @@ fun OverviewScreen(navigationActions: NavigationActions) {
             horizontalArrangement = Arrangement.SpaceBetween) {
               FloatingActionButton(
                   onClick = { navigationActions.navigateTo(Screen.SETTINGS) },
-                  modifier = Modifier.testTag("SettingsFab")) {
+                  modifier = Modifier.testTag("settingsFab")) {
                     Icon(imageVector = Icons.Default.Settings, contentDescription = "Settings")
                   }
-            Text(
-                modifier = Modifier.testTag("appName").weight(1f),
-                text = "SuddenBump!",
-                style =
-                MaterialTheme.typography.headlineMedium.copy(
-                    fontSize = 30.sp,
-                    lineHeight = 44.sp),
-                color = violetColor,
-                fontWeight = FontWeight.Bold,
-                textAlign = TextAlign.Center)
-            
+              Text(
+                  modifier = Modifier.testTag("appName").weight(1f),
+                  text = "SuddenBump!",
+                  style =
+                      MaterialTheme.typography.headlineMedium.copy(
+                          fontSize = 30.sp, lineHeight = 44.sp),
+                  color = violetColor,
+                  fontWeight = FontWeight.Bold,
+                  textAlign = TextAlign.Center)
+
               FloatingActionButton(
                   onClick = { navigationActions.navigateTo(Screen.ADD_CONTACT) },
-                  modifier = Modifier.testTag("AddContactFab")) {
+                  modifier = Modifier.testTag("addContactFab")) {
                     Icon(
                         imageVector = Icons.Default.AccountCircle,
                         contentDescription = "Add Contact")
@@ -72,36 +70,34 @@ fun OverviewScreen(navigationActions: NavigationActions) {
             tabList = LIST_TOP_LEVEL_DESTINATION,
             selectedItem = navigationActions.currentRoute())
       },
-      content = { pd ->  Column(
-          modifier = Modifier.padding(pd), horizontalAlignment = Alignment.CenterHorizontally) {
-
-          if (mockUsers.isNotEmpty()) {
-              LazyColumn { var currentDist: Int? = null
+      content = { pd ->
+        Column(
+            modifier = Modifier.padding(pd), horizontalAlignment = Alignment.CenterHorizontally) {
+              if (mockUsers.isNotEmpty()) {
+                LazyColumn(modifier = Modifier.testTag("userList")) {
+                  var currentDist: Int? = null
                   mockUsers.forEach { user ->
-                      if (currentDist != user.relativeDist) {
-                          currentDist = user.relativeDist
-                          item {
-                              Text(
-                                  text = "Distance: ${user.relativeDist} km",
-                                  modifier = Modifier
-                                      .fillMaxWidth()
-                                      .padding(vertical = 8.dp),
-                                  style = MaterialTheme.typography.headlineSmall
-                              )
-                          }
-                      }
+                    if (currentDist != user.relativeDist) {
+                      currentDist = user.relativeDist
                       item {
-                          UserCard(user = user, navigationActions)
+                        Text(
+                            text = "Distance: ${user.relativeDist} km",
+                            modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                            style = MaterialTheme.typography.headlineSmall)
                       }
-                  } }
-          } else {
-              Text(text = "Looks like no friends are nearby",
-                  modifier = Modifier
-                      .fillMaxWidth()
-                      .padding(vertical = 8.dp),
-                  style = MaterialTheme.typography.titleLarge)
-          }
-      } })
+                    }
+                    item { UserCard(user = user, navigationActions) }
+                  }
+                }
+              } else {
+                Text(
+                    text = "Looks like no friends are nearby",
+                    modifier =
+                        Modifier.testTag("noFriends").fillMaxWidth().padding(vertical = 8.dp),
+                    style = MaterialTheme.typography.titleLarge)
+              }
+            }
+      })
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/swent/suddenbump/ui/overview/Overview.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/overview/Overview.kt
@@ -1,17 +1,23 @@
 package com.swent.suddenbump.ui.overview
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
@@ -22,8 +28,11 @@ import com.swent.suddenbump.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.swent.suddenbump.ui.navigation.NavigationActions
 import com.swent.suddenbump.ui.navigation.Screen
 
+
 @Composable
 fun OverviewScreen(navigationActions: NavigationActions) {
+    val mockUsers = generateMockUsers().sortedBy { it.relativeDist }
+
   Scaffold(
       topBar = {
         Row(
@@ -50,7 +59,31 @@ fun OverviewScreen(navigationActions: NavigationActions) {
             tabList = LIST_TOP_LEVEL_DESTINATION,
             selectedItem = navigationActions.currentRoute())
       },
-      content = { pd -> Text("Overview Screen", modifier = Modifier.padding(pd)) })
+      content = { pd ->  Column(
+          modifier = Modifier.padding(pd), horizontalAlignment = Alignment.CenterHorizontally) {
+          if (mockUsers.isNotEmpty()) {
+              LazyColumn { var currentDist: Int? = null
+                  mockUsers.forEach { user ->
+                      if (currentDist != user.relativeDist) {
+                          currentDist = user.relativeDist
+                          item {
+                              Text(
+                                  text = "Distance: ${user.relativeDist} km",
+                                  modifier = Modifier
+                                      .fillMaxWidth()
+                                      .padding(vertical = 8.dp),
+                                  style = MaterialTheme.typography.headlineSmall
+                              )
+                          }
+                      }
+                      item {
+                          UserCard(user = user, navigationActions)
+                      }
+                  } }
+          } else {
+              Text(text = "Looks like no friends are nearby")
+          }
+      } })
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/swent/suddenbump/ui/overview/Settings.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/overview/Settings.kt
@@ -1,4 +1,4 @@
-package com.swent.suddenbump.ui.settings
+package com.swent.suddenbump.ui.overview
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background

--- a/app/src/test/java/com/swent/suddenbump/ui/navigation/NavigationActionsTest.kt
+++ b/app/src/test/java/com/swent/suddenbump/ui/navigation/NavigationActionsTest.kt
@@ -33,6 +33,9 @@ class NavigationActionsTest {
 
     navigationActions.navigateTo(Screen.MAP)
     verify(navHostController).navigate(Screen.MAP)
+
+    navigationActions.navigateTo(Screen.MESS)
+    verify(navHostController).navigate(Screen.MESS)
   }
 
   @Test


### PR DESCRIPTION
Show users on the overview screen, sorted by their relative distance.
Modify the bottom navigation bar to display the overview icon in the middle
Fix small bug related to navigation actions (when pressing the phone back button, the app used to go back to the sign-In screen)
Add tests for the Overview screen and complete 1 more test for Navigation Actions