### PR TITLE
100 dont let users change email

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - main
       - add-map
       - clean-up
+      - 100-dont-let-users-change-email
 
   pull_request:
     types:

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/authentication/SignUpScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/authentication/SignUpScreenTest.kt
@@ -13,14 +13,11 @@ import com.google.firebase.auth.FirebaseAuth
 import com.swent.suddenbump.model.user.UserRepository
 import com.swent.suddenbump.model.user.UserViewModel
 import com.swent.suddenbump.ui.navigation.NavigationActions
-import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.MockedStatic
-import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.`when`
 
 class SignUpScreenTest {

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/authentication/SignUpScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/authentication/SignUpScreenTest.kt
@@ -64,9 +64,6 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("lastNameField").performTextInput("Doe")
     composeTestRule.onNodeWithTag("lastNameField").assertTextContains("Doe")
 
-    composeTestRule.onNodeWithTag("emailField").performTextInput("john.doe@example.com")
-    composeTestRule.onNodeWithTag("emailField").assertTextContains("john.doe@example.com")
-
     composeTestRule.onNodeWithTag("phoneField").performTextInput("+1234567890")
     composeTestRule.onNodeWithTag("phoneField").assertTextContains("+1 234-567-890")
 

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/authentication/SignUpScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/authentication/SignUpScreenTest.kt
@@ -2,19 +2,25 @@ package com.swent.suddenbump.ui.authentication
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import com.google.firebase.auth.FirebaseAuth
 import com.swent.suddenbump.model.user.UserRepository
 import com.swent.suddenbump.model.user.UserViewModel
 import com.swent.suddenbump.ui.navigation.NavigationActions
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.MockedStatic
+import org.mockito.Mockito.doNothing
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.`when`
 
 class SignUpScreenTest {
@@ -22,6 +28,8 @@ class SignUpScreenTest {
   private lateinit var userRepository: UserRepository
   private lateinit var navigationActions: NavigationActions
   private lateinit var userViewModel: UserViewModel
+  private lateinit var firebaseAuth: FirebaseAuth
+  private lateinit var firebaseAuthMock: MockedStatic<FirebaseAuth>
   @get:Rule val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
   //  @Mock
@@ -33,7 +41,23 @@ class SignUpScreenTest {
     userRepository = mock(UserRepository::class.java)
     navigationActions = mock(NavigationActions::class.java)
     userViewModel = UserViewModel(userRepository)
+    /*firebaseAuth = mock(FirebaseAuth::class.java)
+
+    // Mock the static method getInstance()
+    firebaseAuthMock = mockStatic(FirebaseAuth::class.java)
+    firebaseAuthMock.`when`<FirebaseAuth> { FirebaseAuth.getInstance() }.thenReturn(firebaseAuth)
+
+    doNothing().`when`(firebaseAuth).signOut()
+    `when`(firebaseAuth.currentUser?.email).thenReturn("john.doe@example.com")*/
   }
+
+  /*@After
+  fun tearDown() {
+    // Check if firebaseAuthMock is initialized before closing it
+    if (::firebaseAuthMock.isInitialized) {
+      firebaseAuthMock.close()
+    }
+  }*/
 
   @Test
   fun testSignUpScreen_initialState() {
@@ -43,6 +67,7 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("firstNameField").assertExists()
     composeTestRule.onNodeWithTag("lastNameField").assertExists()
     composeTestRule.onNodeWithTag("emailField").assertExists()
+    composeTestRule.onNodeWithTag("emailField").assertIsNotEnabled()
     composeTestRule.onNodeWithTag("phoneField").assertExists()
     composeTestRule.onNodeWithTag("createAccountButton").assertExists()
 
@@ -63,6 +88,8 @@ class SignUpScreenTest {
 
     composeTestRule.onNodeWithTag("lastNameField").performTextInput("Doe")
     composeTestRule.onNodeWithTag("lastNameField").assertTextContains("Doe")
+
+    composeTestRule.onNodeWithTag("emailField").assertIsNotEnabled()
 
     composeTestRule.onNodeWithTag("phoneField").performTextInput("+1234567890")
     composeTestRule.onNodeWithTag("phoneField").assertTextContains("+1 234-567-890")

--- a/app/src/main/java/com/swent/suddenbump/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/authentication/SignUp.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
+import com.google.firebase.auth.FirebaseAuth
 import com.swent.suddenbump.R
 import com.swent.suddenbump.model.user.User
 import com.swent.suddenbump.model.user.UserViewModel
@@ -39,7 +40,7 @@ import kotlinx.coroutines.launch
 fun SignUpScreen(navigationActions: NavigationActions, userViewModel: UserViewModel) {
   var firstName by remember { mutableStateOf("") }
   var lastName by remember { mutableStateOf("") }
-  var email by remember { mutableStateOf("") }
+  val email = FirebaseAuth.getInstance().currentUser?.email ?: ""
   var phoneNumber by remember { mutableStateOf("") }
   var profilePictureUri by remember { mutableStateOf<Uri?>(null) }
   val coroutineScope = rememberCoroutineScope()
@@ -122,8 +123,9 @@ fun SignUpScreen(navigationActions: NavigationActions, userViewModel: UserViewMo
           Spacer(modifier = Modifier.height(16.dp))
           OutlinedTextField(
               value = email,
-              onValueChange = { email = it },
+              onValueChange = {},
               label = { Text("Email") },
+              enabled = false,
               modifier = Modifier.fillMaxWidth().testTag("emailField"),
           )
           Spacer(modifier = Modifier.height(16.dp))


### PR DESCRIPTION
I disabled the possibility for users to change their email when signing up. Now, the email is directly retrieved from Firebase upon clicking on "Sign in with Google" button.

The field still appears so that users can see which email will be used, but the field is disabled and cannot be edited.

Tests were adapted to fit this new change.