### PR TITLE
Put firend's name in AddMeeting Screen TopAppBar and Add more Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
       - 93-verify-number-with-sms-code
       - 124-connect-google-calendar-to-the-app-to-add-the-meeting-with-your-friends
       - 143-add-and-edit-meetings-on-the-calendar
+      - 149-add-ui-improvements
 
   pull_request:
     types:

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/AddMeetingScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/AddMeetingScreenTest.kt
@@ -23,6 +23,8 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.anyOrNull
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
 
 @RunWith(AndroidJUnit4::class)
 class AddMeetingScreenTest {
@@ -40,6 +42,8 @@ class AddMeetingScreenTest {
 
   @Before
   fun setUp() {
+    MockitoAnnotations.openMocks(this)
+
     meetingRepository = mock(MeetingRepository::class.java)
     userRepository = mock(UserRepository::class.java)
     chatRepository = mock(ChatRepository::class.java)
@@ -48,6 +52,7 @@ class AddMeetingScreenTest {
     userViewModel = UserViewModel(userRepository, chatRepository)
 
     `when`(navigationActions.currentRoute()).thenReturn(Screen.ADD_MEETING)
+    `when`(meetingRepository.getNewMeetingId()).thenReturn("mockedMeetingId")
   }
 
   @Test
@@ -80,5 +85,20 @@ class AddMeetingScreenTest {
     composeTestRule.onNodeWithTag("Save Meeting").performClick()
 
     verify(meetingRepository, never()).addMeeting(anyOrNull(), anyOrNull(), anyOrNull())
+  }
+
+  @Test
+  fun saveButton_savesMeeting() {
+    // Arrange
+    composeTestRule.setContent { AddMeetingScreen(navigationActions, userViewModel, meetingViewModel) }
+
+    // Act
+    composeTestRule.onNodeWithTag("Location").performTextInput("Central Park")
+    composeTestRule.onNodeWithTag("Date").performTextInput("05/09/2024")
+    composeTestRule.onNodeWithTag("Save Meeting").performClick()
+    composeTestRule.waitForIdle()  // Ensure all actions are processed
+
+    // Assert: Check addMeeting is called with any arguments
+    verify(meetingRepository).addMeeting(any(), any(), any())
   }
 }

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/AddMeetingScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/AddMeetingScreenTest.kt
@@ -22,9 +22,9 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
-import org.mockito.kotlin.anyOrNull
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 
 @RunWith(AndroidJUnit4::class)
 class AddMeetingScreenTest {
@@ -90,13 +90,15 @@ class AddMeetingScreenTest {
   @Test
   fun saveButton_savesMeeting() {
     // Arrange
-    composeTestRule.setContent { AddMeetingScreen(navigationActions, userViewModel, meetingViewModel) }
+    composeTestRule.setContent {
+      AddMeetingScreen(navigationActions, userViewModel, meetingViewModel)
+    }
 
     // Act
     composeTestRule.onNodeWithTag("Location").performTextInput("Central Park")
     composeTestRule.onNodeWithTag("Date").performTextInput("05/09/2024")
     composeTestRule.onNodeWithTag("Save Meeting").performClick()
-    composeTestRule.waitForIdle()  // Ensure all actions are processed
+    composeTestRule.waitForIdle() // Ensure all actions are processed
 
     // Assert: Check addMeeting is called with any arguments
     verify(meetingRepository).addMeeting(any(), any(), any())

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/EditMeetingScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/EditMeetingScreenTest.kt
@@ -25,6 +25,10 @@ import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.GregorianCalendar
+import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
 class EditMeetingScreenTest {
@@ -107,9 +111,21 @@ class EditMeetingScreenTest {
     verify(meetingRepository)
         .updateMeeting(meetingCaptor.capture(), successCaptor.capture(), failureCaptor.capture())
 
+    val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+    val parsedDate = dateFormat.parse("05/09/2024")
+    val calendar =
+      GregorianCalendar().apply {
+        time = parsedDate
+        set(Calendar.HOUR_OF_DAY, 0)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+      }
+    val meetingDate = Timestamp(calendar.time)
+
     assertEquals("JhXlhoSvTmbtTFSVpNnA", meetingCaptor.firstValue.meetingId)
     assertEquals("New Location", meetingCaptor.firstValue.location)
-    assertEquals(Timestamp(1725487200, 0), meetingCaptor.firstValue.date)
+    assertEquals(meetingDate, meetingCaptor.firstValue.date)
     assertEquals("FPHuqGkCBo7Iinbo5OO9", meetingCaptor.firstValue.friendId)
     assertEquals("P7vuP4bbEQB03OSR3QwJ", meetingCaptor.firstValue.creatorId)
   }

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/EditMeetingScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/EditMeetingScreenTest.kt
@@ -5,18 +5,26 @@ import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.firebase.Timestamp
 import com.swent.suddenbump.model.meeting.Meeting
 import com.swent.suddenbump.model.meeting.MeetingRepository
 import com.swent.suddenbump.model.meeting.MeetingViewModel
 import com.swent.suddenbump.ui.navigation.NavigationActions
+import junit.framework.TestCase.assertEquals
 import java.util.Date
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 
 @RunWith(AndroidJUnit4::class)
 class EditMeetingScreenTest {
@@ -24,6 +32,8 @@ class EditMeetingScreenTest {
   private lateinit var navigationActions: NavigationActions
   private lateinit var meetingRepository: MeetingRepository
   private lateinit var meetingViewModel: MeetingViewModel
+  private lateinit var viewModel: MeetingViewModel
+
 
   @get:Rule val composeTestRule = createComposeRule()
 
@@ -37,8 +47,11 @@ class EditMeetingScreenTest {
 
   @Before
   fun setUp() {
+    MockitoAnnotations.openMocks(this)
+
     meetingRepository = mock(MeetingRepository::class.java)
     navigationActions = mock(NavigationActions::class.java)
+    viewModel = mock(MeetingViewModel::class.java)
     meetingViewModel = MeetingViewModel(meetingRepository)
   }
 
@@ -73,5 +86,56 @@ class EditMeetingScreenTest {
 
     composeTestRule.onNodeWithTag("Location").assertTextContains("Cafe")
     composeTestRule.onNodeWithTag("Date").assertTextContains("05/09/2024")
+  }
+
+  @Test
+  fun saveButton_updatesMeeting() {
+    // Arrange
+    meetingViewModel.selectMeeting(meeting)
+    composeTestRule.setContent { EditMeetingScreen(navigationActions, meetingViewModel) }
+
+    // Act
+    composeTestRule.onNodeWithTag("Location").performTextClearance()
+    composeTestRule.onNodeWithTag("Location").performTextInput("New Location")
+    composeTestRule.onNodeWithTag("Date").performTextClearance()
+    composeTestRule.onNodeWithTag("Date").performTextInput("05/09/2024")
+    composeTestRule.onNodeWithTag("Save Changes").performClick()
+
+
+    // Assert
+    val meetingCaptor = argumentCaptor<Meeting>()
+    val successCaptor = argumentCaptor<() -> Unit>()
+    val failureCaptor = argumentCaptor<(Exception) -> Unit>()
+    verify(meetingRepository).updateMeeting(
+      meetingCaptor.capture(),
+      successCaptor.capture(),
+      failureCaptor.capture()
+    )
+
+    assertEquals("JhXlhoSvTmbtTFSVpNnA", meetingCaptor.firstValue.meetingId)
+    assertEquals("New Location", meetingCaptor.firstValue.location)
+    assertEquals(Timestamp(1725487200, 0), meetingCaptor.firstValue.date)
+    assertEquals("FPHuqGkCBo7Iinbo5OO9", meetingCaptor.firstValue.friendId)
+    assertEquals("P7vuP4bbEQB03OSR3QwJ", meetingCaptor.firstValue.creatorId)
+
+    }
+
+  @Test
+  fun deleteButton_deletesMeeting() {
+    // Arrange
+    meetingViewModel.selectMeeting(meeting)
+    composeTestRule.setContent { EditMeetingScreen(navigationActions, meetingViewModel) }
+
+    // Act
+    composeTestRule.onNodeWithTag("Delete Meeting").performClick()
+
+    // Assert
+    val successCaptor = argumentCaptor<() -> Unit>()
+    val failureCaptor = argumentCaptor<(Exception) -> Unit>()
+    verify(meetingRepository).deleteMeetingById(
+      eq("JhXlhoSvTmbtTFSVpNnA"),
+      successCaptor.capture(),
+      failureCaptor.capture()
+    )
   }
 }

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/EditMeetingScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/EditMeetingScreenTest.kt
@@ -14,7 +14,11 @@ import com.swent.suddenbump.model.meeting.Meeting
 import com.swent.suddenbump.model.meeting.MeetingRepository
 import com.swent.suddenbump.model.meeting.MeetingViewModel
 import com.swent.suddenbump.ui.navigation.NavigationActions
+import java.text.SimpleDateFormat
+import java.util.Calendar
 import java.util.Date
+import java.util.GregorianCalendar
+import java.util.Locale
 import junit.framework.TestCase.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -25,10 +29,6 @@ import org.mockito.Mockito.verify
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
-import java.text.SimpleDateFormat
-import java.util.Calendar
-import java.util.GregorianCalendar
-import java.util.Locale
 
 @RunWith(AndroidJUnit4::class)
 class EditMeetingScreenTest {
@@ -114,13 +114,13 @@ class EditMeetingScreenTest {
     val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
     val parsedDate = dateFormat.parse("05/09/2024")
     val calendar =
-      GregorianCalendar().apply {
-        time = parsedDate
-        set(Calendar.HOUR_OF_DAY, 0)
-        set(Calendar.MINUTE, 0)
-        set(Calendar.SECOND, 0)
-        set(Calendar.MILLISECOND, 0)
-      }
+        GregorianCalendar().apply {
+          time = parsedDate
+          set(Calendar.HOUR_OF_DAY, 0)
+          set(Calendar.MINUTE, 0)
+          set(Calendar.SECOND, 0)
+          set(Calendar.MILLISECOND, 0)
+        }
     val meetingDate = Timestamp(calendar.time)
 
     assertEquals("JhXlhoSvTmbtTFSVpNnA", meetingCaptor.firstValue.meetingId)

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/EditMeetingScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/EditMeetingScreenTest.kt
@@ -14,8 +14,8 @@ import com.swent.suddenbump.model.meeting.Meeting
 import com.swent.suddenbump.model.meeting.MeetingRepository
 import com.swent.suddenbump.model.meeting.MeetingViewModel
 import com.swent.suddenbump.ui.navigation.NavigationActions
-import junit.framework.TestCase.assertEquals
 import java.util.Date
+import junit.framework.TestCase.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -33,7 +33,6 @@ class EditMeetingScreenTest {
   private lateinit var meetingRepository: MeetingRepository
   private lateinit var meetingViewModel: MeetingViewModel
   private lateinit var viewModel: MeetingViewModel
-
 
   @get:Rule val composeTestRule = createComposeRule()
 
@@ -101,24 +100,19 @@ class EditMeetingScreenTest {
     composeTestRule.onNodeWithTag("Date").performTextInput("05/09/2024")
     composeTestRule.onNodeWithTag("Save Changes").performClick()
 
-
     // Assert
     val meetingCaptor = argumentCaptor<Meeting>()
     val successCaptor = argumentCaptor<() -> Unit>()
     val failureCaptor = argumentCaptor<(Exception) -> Unit>()
-    verify(meetingRepository).updateMeeting(
-      meetingCaptor.capture(),
-      successCaptor.capture(),
-      failureCaptor.capture()
-    )
+    verify(meetingRepository)
+        .updateMeeting(meetingCaptor.capture(), successCaptor.capture(), failureCaptor.capture())
 
     assertEquals("JhXlhoSvTmbtTFSVpNnA", meetingCaptor.firstValue.meetingId)
     assertEquals("New Location", meetingCaptor.firstValue.location)
     assertEquals(Timestamp(1725487200, 0), meetingCaptor.firstValue.date)
     assertEquals("FPHuqGkCBo7Iinbo5OO9", meetingCaptor.firstValue.friendId)
     assertEquals("P7vuP4bbEQB03OSR3QwJ", meetingCaptor.firstValue.creatorId)
-
-    }
+  }
 
   @Test
   fun deleteButton_deletesMeeting() {
@@ -132,10 +126,8 @@ class EditMeetingScreenTest {
     // Assert
     val successCaptor = argumentCaptor<() -> Unit>()
     val failureCaptor = argumentCaptor<(Exception) -> Unit>()
-    verify(meetingRepository).deleteMeetingById(
-      eq("JhXlhoSvTmbtTFSVpNnA"),
-      successCaptor.capture(),
-      failureCaptor.capture()
-    )
+    verify(meetingRepository)
+        .deleteMeetingById(
+            eq("JhXlhoSvTmbtTFSVpNnA"), successCaptor.capture(), failureCaptor.capture())
   }
 }

--- a/app/src/main/java/com/swent/suddenbump/model/meeting/MeetingRepositoryFirestore.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/meeting/MeetingRepositoryFirestore.kt
@@ -42,9 +42,7 @@ class MeetingRepositoryFirestore(private val db: FirebaseFirestore) : MeetingRep
           if (result.isSuccessful) {
             onSuccess()
           } else {
-            result.exception?.let {
-              onFailure(it)
-            }
+            result.exception?.let { onFailure(it) }
           }
         }
   }
@@ -61,9 +59,7 @@ class MeetingRepositoryFirestore(private val db: FirebaseFirestore) : MeetingRep
           if (result.isSuccessful) {
             onSuccess()
           } else {
-            result.exception?.let {
-              onFailure(it)
-            }
+            result.exception?.let { onFailure(it) }
           }
         }
   }
@@ -77,9 +73,7 @@ class MeetingRepositoryFirestore(private val db: FirebaseFirestore) : MeetingRep
       if (result.isSuccessful) {
         onSuccess()
       } else {
-        result.exception?.let {
-          onFailure(it)
-        }
+        result.exception?.let { onFailure(it) }
       }
     }
   }

--- a/app/src/main/java/com/swent/suddenbump/model/meeting/MeetingRepositoryFirestore.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/meeting/MeetingRepositoryFirestore.kt
@@ -43,7 +43,6 @@ class MeetingRepositoryFirestore(private val db: FirebaseFirestore) : MeetingRep
             onSuccess()
           } else {
             result.exception?.let {
-              Log.e("MeetingRepositoryFirestore", "Error adding document", it)
               onFailure(it)
             }
           }
@@ -63,7 +62,6 @@ class MeetingRepositoryFirestore(private val db: FirebaseFirestore) : MeetingRep
             onSuccess()
           } else {
             result.exception?.let {
-              Log.e("MeetingRepositoryFirestore", "Error updating document", it)
               onFailure(it)
             }
           }
@@ -80,7 +78,6 @@ class MeetingRepositoryFirestore(private val db: FirebaseFirestore) : MeetingRep
         onSuccess()
       } else {
         result.exception?.let {
-          Log.e("MeetingRepositoryFirestore", "Error deleting document", it)
           onFailure(it)
         }
       }

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/AddMeeting.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/AddMeeting.kt
@@ -38,7 +38,7 @@ fun AddMeetingScreen(
         TopAppBar(
             title = {
               Text(
-                  "Add New Meeting",
+                  "Schedule New Meeting with ${userViewModel.user?.firstName?: ""} ${userViewModel.user?.lastName?: ""}",
                   color = Color.White,
                   modifier = Modifier.testTag("Add New Meeting"))
             },

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/AddMeeting.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/AddMeeting.kt
@@ -38,7 +38,7 @@ fun AddMeetingScreen(
         TopAppBar(
             title = {
               Text(
-                  "Schedule New Meeting with ${userViewModel.user?.firstName?: ""} ${userViewModel.user?.lastName?: ""}",
+                  "Add Meeting with ${userViewModel.user?.firstName?: ""}",
                   color = Color.White,
                   modifier = Modifier.testTag("Add New Meeting"))
             },

--- a/app/src/test/java/com/swent/suddenbump/model/meeting/MeetingRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/meeting/MeetingRepositoryFirestoreTest.kt
@@ -10,6 +10,7 @@ import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.QuerySnapshot
+import junit.framework.TestCase.assertTrue
 import junit.framework.TestCase.fail
 import org.junit.Before
 import org.junit.Test
@@ -99,5 +100,58 @@ class MeetingRepositoryFirestoreTest {
     shadowOf(Looper.getMainLooper()).idle() // Ensure all asynchronous operations complete
 
     verify(mockDocumentReference).delete()
+  }
+
+  @Test
+  fun updateMeeting_shouldCallFirestoreCollection() {
+    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forResult(null)) // Simulate success
+
+    meetingRepositoryFirestore.updateMeeting(meeting, onSuccess = {}, onFailure = {})
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify(mockDocumentReference).set(any())
+  }
+
+  @Test
+  fun updateMeeting_shouldCallOnFailure_whenFirestoreFails() {
+    val exception = Exception("Firestore update failed")
+    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forException(exception)) // Simulate failure
+
+    var onFailureCalled = false
+    meetingRepositoryFirestore.updateMeeting(meeting, onSuccess = {}, onFailure = { onFailureCalled = true })
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify(mockDocumentReference).set(any())
+    assertTrue(onFailureCalled)
+  }
+
+  @Test
+  fun deleteMeetingById_shouldCallOnFailure_whenFirestoreFails() {
+    val exception = Exception("Firestore delete failed")
+    `when`(mockDocumentReference.delete()).thenReturn(Tasks.forException(exception)) // Simulate failure
+
+    var onFailureCalled = false
+    meetingRepositoryFirestore.deleteMeetingById("1", onSuccess = {}, onFailure = { onFailureCalled = true })
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify(mockDocumentReference).delete()
+    assertTrue(onFailureCalled)
+  }
+
+  @Test
+  fun addMeeting_shouldCallOnFailure_whenFirestoreFails() {
+    val exception = Exception("Firestore add failed")
+    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forException(exception)) // Simulate failure
+
+    var onFailureCalled = false
+    meetingRepositoryFirestore.addMeeting(meeting, onSuccess = {}, onFailure = { onFailureCalled = true })
+
+    shadowOf(Looper.getMainLooper()).idle()
+
+    verify(mockDocumentReference).set(any())
+    assertTrue(onFailureCalled)
   }
 }

--- a/app/src/test/java/com/swent/suddenbump/model/meeting/MeetingRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/meeting/MeetingRepositoryFirestoreTest.kt
@@ -116,10 +116,12 @@ class MeetingRepositoryFirestoreTest {
   @Test
   fun updateMeeting_shouldCallOnFailure_whenFirestoreFails() {
     val exception = Exception("Firestore update failed")
-    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forException(exception)) // Simulate failure
+    `when`(mockDocumentReference.set(any()))
+        .thenReturn(Tasks.forException(exception)) // Simulate failure
 
     var onFailureCalled = false
-    meetingRepositoryFirestore.updateMeeting(meeting, onSuccess = {}, onFailure = { onFailureCalled = true })
+    meetingRepositoryFirestore.updateMeeting(
+        meeting, onSuccess = {}, onFailure = { onFailureCalled = true })
 
     shadowOf(Looper.getMainLooper()).idle()
 
@@ -130,10 +132,12 @@ class MeetingRepositoryFirestoreTest {
   @Test
   fun deleteMeetingById_shouldCallOnFailure_whenFirestoreFails() {
     val exception = Exception("Firestore delete failed")
-    `when`(mockDocumentReference.delete()).thenReturn(Tasks.forException(exception)) // Simulate failure
+    `when`(mockDocumentReference.delete())
+        .thenReturn(Tasks.forException(exception)) // Simulate failure
 
     var onFailureCalled = false
-    meetingRepositoryFirestore.deleteMeetingById("1", onSuccess = {}, onFailure = { onFailureCalled = true })
+    meetingRepositoryFirestore.deleteMeetingById(
+        "1", onSuccess = {}, onFailure = { onFailureCalled = true })
 
     shadowOf(Looper.getMainLooper()).idle()
 
@@ -144,10 +148,12 @@ class MeetingRepositoryFirestoreTest {
   @Test
   fun addMeeting_shouldCallOnFailure_whenFirestoreFails() {
     val exception = Exception("Firestore add failed")
-    `when`(mockDocumentReference.set(any())).thenReturn(Tasks.forException(exception)) // Simulate failure
+    `when`(mockDocumentReference.set(any()))
+        .thenReturn(Tasks.forException(exception)) // Simulate failure
 
     var onFailureCalled = false
-    meetingRepositoryFirestore.addMeeting(meeting, onSuccess = {}, onFailure = { onFailureCalled = true })
+    meetingRepositoryFirestore.addMeeting(
+        meeting, onSuccess = {}, onFailure = { onFailureCalled = true })
 
     shadowOf(Looper.getMainLooper()).idle()
 

--- a/app/src/test/java/com/swent/suddenbump/model/meeting/MeetingViewModelTest.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/meeting/MeetingViewModelTest.kt
@@ -6,7 +6,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.hamcrest.CoreMatchers.`is`
 import org.hamcrest.MatcherAssert.assertThat
@@ -69,5 +71,23 @@ class MeetingViewModelTest {
   fun addMeetingCallsRepository() {
     meetingViewModel.addMeeting(meeting)
     verify(meetingRepository).addMeeting(eq(meeting), any(), any())
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun deleteMeeting_callsRepositoryDelete() = runTest {
+    meetingViewModel.deleteMeeting("JhXlhoSvTmbtTFSVpNnA")
+    // Advance the coroutine to ensure it completes
+    advanceUntilIdle()
+    verify(meetingRepository).deleteMeetingById(eq("JhXlhoSvTmbtTFSVpNnA"), any(), any())
+  }
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @Test
+  fun updateMeeting_callsRepositoryUpdate()  = runTest {
+    meetingViewModel.updateMeeting(meeting)
+    // Advance the coroutine to ensure it completes
+    advanceUntilIdle()
+    verify(meetingRepository).updateMeeting(eq(meeting), any(), any())
   }
 }

--- a/app/src/test/java/com/swent/suddenbump/model/meeting/MeetingViewModelTest.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/meeting/MeetingViewModelTest.kt
@@ -28,7 +28,7 @@ class MeetingViewModelTest {
 
   private val testDispatcher = StandardTestDispatcher()
 
-  val meeting =
+  private val meeting =
       Meeting(
           meetingId = "JhXlhoSvTmbtTFSVpNnA",
           location = "Cafe",
@@ -84,7 +84,7 @@ class MeetingViewModelTest {
 
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
-  fun updateMeeting_callsRepositoryUpdate()  = runTest {
+  fun updateMeeting_callsRepositoryUpdate() = runTest {
     meetingViewModel.updateMeeting(meeting)
     // Advance the coroutine to ensure it completes
     advanceUntilIdle()


### PR DESCRIPTION
- This PR enhances the AddMeeting screen by displaying the friend’s name in the TopAppBar title. 
- It also expands unit test coverage for the MeetingViewModel and MeetingRepositoryFirestore, and adds additional UI tests for both the AddMeeting and EditMeeting screens.