### PR TITLE
Add pop out calendar when choosing date in the AddMeeting and EditMeeting screens

### DIFF
--- a/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/AddMeetingScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/AddMeetingScreenTest.kt
@@ -68,6 +68,8 @@ class AddMeetingScreenTest {
     composeTestRule.onNodeWithTag("Location").performTextInput("Central Park")
     // Input date
     composeTestRule.onNodeWithTag("Date").assertIsDisplayed()
+    // Edit date icon button
+    composeTestRule.onNodeWithTag("DateIconButton").assertIsDisplayed()
     composeTestRule.onNodeWithTag("Date").performTextInput("25/12/2024")
     // Click save button
     composeTestRule.onNodeWithTag("Save Meeting").assertIsDisplayed()
@@ -103,4 +105,32 @@ class AddMeetingScreenTest {
     // Assert: Check addMeeting is called with any arguments
     verify(meetingRepository).addMeeting(any(), any(), any())
   }
+
+  /*@Test
+  fun datePickerDialog_isShown_whenIconButtonIsPressed() {
+    composeTestRule.setContent {
+      AddMeetingScreen(navigationActions, userViewModel, meetingViewModel)
+    }
+
+    // Perform click on the IconButton inside the OutlinedTextField
+    composeTestRule.onNodeWithTag("DateIconButton").performClick()
+
+    // Wait for the dialog to be displayed
+    onView(isRoot()).perform(waitFor(500))
+    // Check if the DatePickerDialog is displayed
+    // Check if a native dialog is displayed
+    onView(withId(android.R.id.datePicker)).perform(PickerActions.setDate(2024, 11, 20));
+
+  }*/
+
+  // Custom wait action
+  /*private fun waitFor(delay: Long): ViewAction {
+    return object : ViewAction {
+      override fun getConstraints(): Matcher<View> = isRoot()
+      override fun getDescription(): String = "Wait for $delay milliseconds."
+      override fun perform(uiController: UiController, view: View?) {
+        uiController.loopMainThreadForAtLeast(delay)
+      }
+    }
+  }*/
 }

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/EditMeetingScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/EditMeetingScreenTest.kt
@@ -70,6 +70,8 @@ class EditMeetingScreenTest {
     composeTestRule.onNodeWithTag("Back").assertIsDisplayed()
     // Input location
     composeTestRule.onNodeWithTag("Location").assertIsDisplayed()
+    // Edit date icon button
+    composeTestRule.onNodeWithTag("DateIconButton").assertIsDisplayed()
     // Input date
     composeTestRule.onNodeWithTag("Date").assertIsDisplayed()
     // Click save button

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/AddMeeting.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/AddMeeting.kt
@@ -78,10 +78,9 @@ fun AddMeetingScreen(
                 // Date Field (Non-clickable)
                 OutlinedTextField(
                     value = date,
-                    onValueChange = {},
+                    onValueChange = { date = it },
                     label = { Text("Date (dd/MM/yyyy)") },
                     textStyle = TextStyle(color = Color.White),
-                    readOnly = true,
                     modifier = Modifier
                         .fillMaxWidth(),
                     trailingIcon = {

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/AddMeeting.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/AddMeeting.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -13,6 +14,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.TextStyle
 import com.google.firebase.Timestamp
 import com.swent.suddenbump.model.meeting.Meeting
 import com.swent.suddenbump.model.meeting.MeetingViewModel
@@ -28,80 +30,137 @@ fun AddMeetingScreen(
     userViewModel: UserViewModel,
     meetingViewModel: MeetingViewModel
 ) {
-  var location by remember { mutableStateOf("") }
-  var date by remember { mutableStateOf("") }
-  val friendId = userViewModel.user?.uid ?: ""
-  val context = LocalContext.current
+    var location by remember { mutableStateOf("") }
+    var date by remember { mutableStateOf("") }
+    var showDatePicker by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+    val friendId = userViewModel.user?.uid ?: ""
 
-  Scaffold(
-      topBar = {
-        TopAppBar(
-            title = {
-              Text(
-                  "Add Meeting with ${userViewModel.user?.firstName?: ""}",
-                  color = Color.White,
-                  modifier = Modifier.testTag("Add New Meeting"))
-            },
-            navigationIcon = {
-              IconButton(
-                  onClick = { navigationActions.goBack() }, modifier = Modifier.testTag("Back")) {
-                    Icon(Icons.Default.ArrowBack, contentDescription = "Back", tint = Color.White)
-                  }
-            },
-            colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Black))
-      },
-      content = { padding ->
-        Column(
-            modifier =
-                Modifier.padding(padding).fillMaxSize().background(Color.Black).padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)) {
-              OutlinedTextField(
-                  value = location,
-                  onValueChange = { location = it },
-                  label = { Text("Location") },
-                  textStyle = LocalTextStyle.current.copy(color = Color.White),
-                  modifier = Modifier.fillMaxWidth().testTag("Location"))
-              OutlinedTextField(
-                  value = date,
-                  onValueChange = { date = it },
-                  label = { Text("Date (dd/MM/yyyy)") },
-                  textStyle = LocalTextStyle.current.copy(color = Color.White),
-                  modifier = Modifier.fillMaxWidth().testTag("Date"))
-              Spacer(modifier = Modifier.height(16.dp))
-              Button(
-                  onClick = {
-                    try {
-                      val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
-                      val parsedDate = dateFormat.parse(date)
-                      val calendar =
-                          GregorianCalendar().apply {
-                            time = parsedDate
-                            set(Calendar.HOUR_OF_DAY, 0)
-                            set(Calendar.MINUTE, 0)
-                            set(Calendar.SECOND, 0)
-                            set(Calendar.MILLISECOND, 0)
-                          }
-                      val meetingDate = Timestamp(calendar.time)
-
-                      val newMeeting =
-                          Meeting(
-                              meetingId = meetingViewModel.getNewMeetingid(),
-                              friendId = friendId,
-                              location = location,
-                              date = meetingDate,
-                              creatorId = userViewModel.getCurrentUser().value?.uid ?: "")
-                      meetingViewModel.addMeeting(newMeeting)
-                      Toast.makeText(context, "Meeting created successfully", Toast.LENGTH_SHORT)
-                          .show()
-                      navigationActions.goBack()
-                    } catch (e: Exception) {
-                      Log.e("AddMeetingScreen", "Error parsing date", e)
-                      Toast.makeText(context, "Invalid date format", Toast.LENGTH_SHORT).show()
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        "Add Meeting with ${userViewModel.user?.firstName ?: ""}",
+                        color = Color.White,
+                        modifier = Modifier.testTag("Add New Meeting")
+                    )
+                },
+                navigationIcon = {
+                    IconButton(
+                        onClick = { navigationActions.goBack() },
+                        modifier = Modifier.testTag("Back")
+                    ) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back", tint = Color.White)
                     }
-                  },
-                  modifier = Modifier.fillMaxWidth().testTag("Save Meeting")) {
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Black)
+            )
+        },
+        content = { padding ->
+            Column(
+                modifier = Modifier
+                    .padding(padding)
+                    .fillMaxSize()
+                    .background(Color.Black)
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                // Location field
+                OutlinedTextField(
+                    value = location,
+                    onValueChange = { location = it },
+                    label = { Text("Location") },
+                    textStyle = LocalTextStyle.current.copy(color = Color.White),
+                    modifier = Modifier.fillMaxWidth().testTag("Location")
+                )
+
+                // Date Field (Non-clickable)
+                OutlinedTextField(
+                    value = date,
+                    onValueChange = {},
+                    label = { Text("Date (dd/MM/yyyy)") },
+                    textStyle = TextStyle(color = Color.White),
+                    readOnly = true,
+                    modifier = Modifier
+                        .fillMaxWidth(),
+                    trailingIcon = {
+                        IconButton(
+                            onClick = { showDatePicker = true }
+                        ) {
+                            Icon(Icons.Filled.Edit, contentDescription = "Pick a date")
+                        }
+                    }
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Button(
+                    onClick = {
+                        try {
+                            val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+                            val parsedDate = dateFormat.parse(date)
+                            val calendar = GregorianCalendar().apply {
+                                time = parsedDate
+                                set(Calendar.HOUR_OF_DAY, 0)
+                                set(Calendar.MINUTE, 0)
+                                set(Calendar.SECOND, 0)
+                                set(Calendar.MILLISECOND, 0)
+                            }
+                            val meetingDate = Timestamp(calendar.time)
+
+                            val newMeeting = Meeting(
+                                meetingId = meetingViewModel.getNewMeetingid(),
+                                friendId = friendId,
+                                location = location,
+                                date = meetingDate,
+                                creatorId = userViewModel.getCurrentUser().value?.uid ?: ""
+                            )
+                            meetingViewModel.addMeeting(newMeeting)
+                            Toast.makeText(context, "Meeting created successfully", Toast.LENGTH_SHORT).show()
+                            navigationActions.goBack()
+                        } catch (e: Exception) {
+                            Log.e("AddMeetingScreen", "Error parsing date", e)
+                            Toast.makeText(context, "Invalid date format", Toast.LENGTH_SHORT).show()
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth().testTag("Save Meeting")
+                ) {
                     Text("Save Meeting")
-                  }
+                }
+
+                // Show Date Picker Dialog if needed
+                if (showDatePicker) {
+                    val calendar = Calendar.getInstance()
+                    val year = calendar.get(Calendar.YEAR)
+                    val month = calendar.get(Calendar.MONTH)
+                    val day = calendar.get(Calendar.DAY_OF_MONTH)
+
+                    val datePickerDialog = android.app.DatePickerDialog(
+                        context,
+                        { _, y, m, d ->
+                            val selectedCalendar = Calendar.getInstance().apply {
+                                set(Calendar.YEAR, y)
+                                set(Calendar.MONTH, m)
+                                set(Calendar.DAY_OF_MONTH, d)
+                            }
+                            val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+                            date = dateFormat.format(selectedCalendar.time)
+                            showDatePicker = false
+                        }, year, month, day
+                    )
+                    datePickerDialog.show()
+                }
             }
-      })
+        }
+    )
 }
+
+
+
+
+
+
+
+
+

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/AddMeeting.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/AddMeeting.kt
@@ -13,8 +13,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
 import com.google.firebase.Timestamp
 import com.swent.suddenbump.model.meeting.Meeting
 import com.swent.suddenbump.model.meeting.MeetingViewModel
@@ -30,136 +30,121 @@ fun AddMeetingScreen(
     userViewModel: UserViewModel,
     meetingViewModel: MeetingViewModel
 ) {
-    var location by remember { mutableStateOf("") }
-    var date by remember { mutableStateOf("") }
-    var showDatePicker by remember { mutableStateOf(false) }
-    val context = LocalContext.current
-    val friendId = userViewModel.user?.uid ?: ""
+  var location by remember { mutableStateOf("") }
+  var date by remember { mutableStateOf("") }
+  var showDatePicker by remember { mutableStateOf(false) }
+  val context = LocalContext.current
+  val friendId = userViewModel.user?.uid ?: ""
 
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        "Add Meeting with ${userViewModel.user?.firstName ?: ""}",
-                        color = Color.White,
-                        modifier = Modifier.testTag("Add New Meeting")
-                    )
-                },
-                navigationIcon = {
+  Scaffold(
+      topBar = {
+        TopAppBar(
+            title = {
+              Text(
+                  "Add Meeting with ${userViewModel.user?.firstName ?: ""}",
+                  color = Color.White,
+                  modifier = Modifier.testTag("Add New Meeting"))
+            },
+            navigationIcon = {
+              IconButton(
+                  onClick = { navigationActions.goBack() }, modifier = Modifier.testTag("Back")) {
+                    Icon(Icons.Default.ArrowBack, contentDescription = "Back", tint = Color.White)
+                  }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Black))
+      },
+      content = { padding ->
+        Column(
+            modifier =
+                Modifier.padding(padding).fillMaxSize().background(Color.Black).padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)) {
+              // Location field
+              OutlinedTextField(
+                  value = location,
+                  onValueChange = { location = it },
+                  label = { Text("Location") },
+                  textStyle = LocalTextStyle.current.copy(color = Color.White),
+                  modifier = Modifier.fillMaxWidth().testTag("Location"))
+
+              // Date Field (Non-clickable)
+              OutlinedTextField(
+                  value = date,
+                  onValueChange = { date = it },
+                  label = { Text("Date (dd/MM/yyyy)") },
+                  textStyle = TextStyle(color = Color.White),
+                  modifier = Modifier.fillMaxWidth().testTag("Date"),
+                  trailingIcon = {
                     IconButton(
-                        onClick = { navigationActions.goBack() },
-                        modifier = Modifier.testTag("Back")
-                    ) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Back", tint = Color.White)
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Black)
-            )
-        },
-        content = { padding ->
-            Column(
-                modifier = Modifier
-                    .padding(padding)
-                    .fillMaxSize()
-                    .background(Color.Black)
-                    .padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                // Location field
-                OutlinedTextField(
-                    value = location,
-                    onValueChange = { location = it },
-                    label = { Text("Location") },
-                    textStyle = LocalTextStyle.current.copy(color = Color.White),
-                    modifier = Modifier.fillMaxWidth().testTag("Location")
-                )
-
-                // Date Field (Non-clickable)
-                OutlinedTextField(
-                    value = date,
-                    onValueChange = { date = it },
-                    label = { Text("Date (dd/MM/yyyy)") },
-                    textStyle = TextStyle(color = Color.White),
-                    modifier = Modifier
-                        .fillMaxWidth(),
-                    trailingIcon = {
-                        IconButton(
-                            onClick = { showDatePicker = true }
-                        ) {
-                            Icon(Icons.Filled.Edit, contentDescription = "Pick a date")
+                        onClick = { showDatePicker = true },
+                        modifier = Modifier.testTag("DateIconButton")) {
+                          Icon(Icons.Filled.Edit, contentDescription = "Pick a date")
                         }
+                  })
+
+              Spacer(modifier = Modifier.height(16.dp))
+
+              Button(
+                  onClick = {
+                    try {
+                      val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+                      val parsedDate = dateFormat.parse(date)
+                      val calendar =
+                          GregorianCalendar().apply {
+                            time = parsedDate
+                            set(Calendar.HOUR_OF_DAY, 0)
+                            set(Calendar.MINUTE, 0)
+                            set(Calendar.SECOND, 0)
+                            set(Calendar.MILLISECOND, 0)
+                          }
+                      val meetingDate = Timestamp(calendar.time)
+
+                      val newMeeting =
+                          Meeting(
+                              meetingId = meetingViewModel.getNewMeetingid(),
+                              friendId = friendId,
+                              location = location,
+                              date = meetingDate,
+                              creatorId = userViewModel.getCurrentUser().value?.uid ?: "")
+                      meetingViewModel.addMeeting(newMeeting)
+                      Toast.makeText(context, "Meeting created successfully", Toast.LENGTH_SHORT)
+                          .show()
+                      navigationActions.goBack()
+                    } catch (e: Exception) {
+                      Log.e("AddMeetingScreen", "Error parsing date", e)
+                      Toast.makeText(context, "Invalid date format", Toast.LENGTH_SHORT).show()
                     }
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Button(
-                    onClick = {
-                        try {
-                            val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
-                            val parsedDate = dateFormat.parse(date)
-                            val calendar = GregorianCalendar().apply {
-                                time = parsedDate
-                                set(Calendar.HOUR_OF_DAY, 0)
-                                set(Calendar.MINUTE, 0)
-                                set(Calendar.SECOND, 0)
-                                set(Calendar.MILLISECOND, 0)
-                            }
-                            val meetingDate = Timestamp(calendar.time)
-
-                            val newMeeting = Meeting(
-                                meetingId = meetingViewModel.getNewMeetingid(),
-                                friendId = friendId,
-                                location = location,
-                                date = meetingDate,
-                                creatorId = userViewModel.getCurrentUser().value?.uid ?: ""
-                            )
-                            meetingViewModel.addMeeting(newMeeting)
-                            Toast.makeText(context, "Meeting created successfully", Toast.LENGTH_SHORT).show()
-                            navigationActions.goBack()
-                        } catch (e: Exception) {
-                            Log.e("AddMeetingScreen", "Error parsing date", e)
-                            Toast.makeText(context, "Invalid date format", Toast.LENGTH_SHORT).show()
-                        }
-                    },
-                    modifier = Modifier.fillMaxWidth().testTag("Save Meeting")
-                ) {
+                  },
+                  modifier = Modifier.fillMaxWidth().testTag("Save Meeting")) {
                     Text("Save Meeting")
-                }
+                  }
 
-                // Show Date Picker Dialog if needed
-                if (showDatePicker) {
-                    val calendar = Calendar.getInstance()
-                    val year = calendar.get(Calendar.YEAR)
-                    val month = calendar.get(Calendar.MONTH)
-                    val day = calendar.get(Calendar.DAY_OF_MONTH)
+              // Show Date Picker Dialog if needed
+              if (showDatePicker) {
+                val calendar = Calendar.getInstance()
+                val year = calendar.get(Calendar.YEAR)
+                val month = calendar.get(Calendar.MONTH)
+                val day = calendar.get(Calendar.DAY_OF_MONTH)
 
-                    val datePickerDialog = android.app.DatePickerDialog(
+                val datePickerDialog =
+                    android.app.DatePickerDialog(
                         context,
                         { _, y, m, d ->
-                            val selectedCalendar = Calendar.getInstance().apply {
+                          val selectedCalendar =
+                              Calendar.getInstance().apply {
                                 set(Calendar.YEAR, y)
                                 set(Calendar.MONTH, m)
                                 set(Calendar.DAY_OF_MONTH, d)
-                            }
-                            val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
-                            date = dateFormat.format(selectedCalendar.time)
-                            showDatePicker = false
-                        }, year, month, day
-                    )
-                    datePickerDialog.show()
-                }
+                              }
+                          val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+                          date = dateFormat.format(selectedCalendar.time)
+                          showDatePicker = false
+                        },
+                        year,
+                        month,
+                        day)
+
+                datePickerDialog.show()
+              }
             }
-        }
-    )
+      })
 }
-
-
-
-
-
-
-
-
-

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/EditMeeting.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/EditMeeting.kt
@@ -65,10 +65,9 @@ fun EditMeetingScreen(navigationActions: NavigationActions, meetingViewModel: Me
             // Date Field (Non-clickable)
             OutlinedTextField(
                 value = date,
-                onValueChange = {},
+                onValueChange = { date = it },
                 label = { Text("Date (dd/MM/yyyy)") },
                 textStyle = TextStyle(color = Color.White),
-                readOnly = true,
                 modifier = Modifier
                     .fillMaxWidth(),
                 trailingIcon = {

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/EditMeeting.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/EditMeeting.kt
@@ -6,12 +6,14 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import com.google.firebase.Timestamp
 import com.swent.suddenbump.model.meeting.MeetingViewModel
@@ -33,6 +35,7 @@ fun EditMeetingScreen(navigationActions: NavigationActions, meetingViewModel: Me
         } ?: "")
   }
   val context = LocalContext.current
+    var showDatePicker by remember { mutableStateOf(false) }
 
   Scaffold(
       topBar = {
@@ -59,12 +62,23 @@ fun EditMeetingScreen(navigationActions: NavigationActions, meetingViewModel: Me
                   label = { Text("Location") },
                   textStyle = LocalTextStyle.current.copy(color = Color.White),
                   modifier = Modifier.fillMaxWidth().testTag("Location"))
-              OutlinedTextField(
-                  value = date,
-                  onValueChange = { date = it },
-                  label = { Text("Date (dd/MM/yyyy)") },
-                  textStyle = LocalTextStyle.current.copy(color = Color.White),
-                  modifier = Modifier.fillMaxWidth().testTag("Date"))
+            // Date Field (Non-clickable)
+            OutlinedTextField(
+                value = date,
+                onValueChange = {},
+                label = { Text("Date (dd/MM/yyyy)") },
+                textStyle = TextStyle(color = Color.White),
+                readOnly = true,
+                modifier = Modifier
+                    .fillMaxWidth(),
+                trailingIcon = {
+                    IconButton(
+                        onClick = { showDatePicker = true }
+                    ) {
+                        Icon(Icons.Filled.Edit, contentDescription = "Pick a date")
+                    }
+                }
+            )
               Spacer(modifier = Modifier.height(16.dp))
               Button(
                   onClick = {
@@ -110,6 +124,29 @@ fun EditMeetingScreen(navigationActions: NavigationActions, meetingViewModel: Me
                   colors = ButtonDefaults.buttonColors(containerColor = Pink40)) {
                     Text("Delete Meeting")
                   }
+
+            // Show Date Picker Dialog if needed
+            if (showDatePicker) {
+                val calendar = Calendar.getInstance()
+                val year = calendar.get(Calendar.YEAR)
+                val month = calendar.get(Calendar.MONTH)
+                val day = calendar.get(Calendar.DAY_OF_MONTH)
+
+                val datePickerDialog = android.app.DatePickerDialog(
+                    context,
+                    { _, y, m, d ->
+                        val selectedCalendar = Calendar.getInstance().apply {
+                            set(Calendar.YEAR, y)
+                            set(Calendar.MONTH, m)
+                            set(Calendar.DAY_OF_MONTH, d)
+                        }
+                        val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+                        date = dateFormat.format(selectedCalendar.time)
+                        showDatePicker = false
+                    }, year, month, day
+                )
+                datePickerDialog.show()
+            }
             }
       })
 }

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/EditMeeting.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/EditMeeting.kt
@@ -35,7 +35,7 @@ fun EditMeetingScreen(navigationActions: NavigationActions, meetingViewModel: Me
         } ?: "")
   }
   val context = LocalContext.current
-    var showDatePicker by remember { mutableStateOf(false) }
+  var showDatePicker by remember { mutableStateOf(false) }
 
   Scaffold(
       topBar = {
@@ -62,22 +62,20 @@ fun EditMeetingScreen(navigationActions: NavigationActions, meetingViewModel: Me
                   label = { Text("Location") },
                   textStyle = LocalTextStyle.current.copy(color = Color.White),
                   modifier = Modifier.fillMaxWidth().testTag("Location"))
-            // Date Field (Non-clickable)
-            OutlinedTextField(
-                value = date,
-                onValueChange = { date = it },
-                label = { Text("Date (dd/MM/yyyy)") },
-                textStyle = TextStyle(color = Color.White),
-                modifier = Modifier
-                    .fillMaxWidth(),
-                trailingIcon = {
+              // Date Field (Non-clickable)
+              OutlinedTextField(
+                  value = date,
+                  onValueChange = { date = it },
+                  label = { Text("Date (dd/MM/yyyy)") },
+                  textStyle = TextStyle(color = Color.White),
+                  modifier = Modifier.fillMaxWidth().testTag("Date"),
+                  trailingIcon = {
                     IconButton(
-                        onClick = { showDatePicker = true }
-                    ) {
-                        Icon(Icons.Filled.Edit, contentDescription = "Pick a date")
-                    }
-                }
-            )
+                        onClick = { showDatePicker = true },
+                        modifier = Modifier.testTag("DateIconButton")) {
+                          Icon(Icons.Filled.Edit, contentDescription = "Pick a date")
+                        }
+                  })
               Spacer(modifier = Modifier.height(16.dp))
               Button(
                   onClick = {
@@ -124,28 +122,32 @@ fun EditMeetingScreen(navigationActions: NavigationActions, meetingViewModel: Me
                     Text("Delete Meeting")
                   }
 
-            // Show Date Picker Dialog if needed
-            if (showDatePicker) {
+              // Show Date Picker Dialog if needed
+              if (showDatePicker) {
                 val calendar = Calendar.getInstance()
                 val year = calendar.get(Calendar.YEAR)
                 val month = calendar.get(Calendar.MONTH)
                 val day = calendar.get(Calendar.DAY_OF_MONTH)
 
-                val datePickerDialog = android.app.DatePickerDialog(
-                    context,
-                    { _, y, m, d ->
-                        val selectedCalendar = Calendar.getInstance().apply {
-                            set(Calendar.YEAR, y)
-                            set(Calendar.MONTH, m)
-                            set(Calendar.DAY_OF_MONTH, d)
-                        }
-                        val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
-                        date = dateFormat.format(selectedCalendar.time)
-                        showDatePicker = false
-                    }, year, month, day
-                )
+                val datePickerDialog =
+                    android.app.DatePickerDialog(
+                        context,
+                        { _, y, m, d ->
+                          val selectedCalendar =
+                              Calendar.getInstance().apply {
+                                set(Calendar.YEAR, y)
+                                set(Calendar.MONTH, m)
+                                set(Calendar.DAY_OF_MONTH, d)
+                              }
+                          val dateFormat = SimpleDateFormat("dd/MM/yyyy", Locale.getDefault())
+                          date = dateFormat.format(selectedCalendar.time)
+                          showDatePicker = false
+                        },
+                        year,
+                        month,
+                        day)
                 datePickerDialog.show()
-            }
+              }
             }
       })
 }


### PR DESCRIPTION
- Besides the option of typing the date of a meeting, this PR adds the possibility of selecting the date directly from a pop-out calendar, that appears when the edit button inside the Location OutlinedTextField is pressed.