### PR TITLE
Accept/ Reject Meetings inside the PendingMeetings Screen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
       - 124-connect-google-calendar-to-the-app-to-add-the-meeting-with-your-friends
       - 143-add-and-edit-meetings-on-the-calendar
       - 149-add-ui-improvements
+      - 193-acceptingrejecting-meetings
 
   pull_request:
     types:

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/CalendarMeetingsTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/CalendarMeetingsTest.kt
@@ -52,7 +52,8 @@ class CalendarMeetingsTest {
   @Test
   fun hasRequiredComponents() {
     composeTestRule.onNodeWithTag("calendarMeetingsScreen").assertIsDisplayed()
-    composeTestRule.onNodeWithTag("monthYearHeader").assertIsDisplayed()
+    composeTestRule.onAllNodesWithTag("monthYearHeader")[0].assertIsDisplayed()
+    composeTestRule.onAllNodesWithTag("monthYearHeader")[1].assertIsDisplayed()
     composeTestRule.onAllNodesWithTag("dayRow")[0].assertIsDisplayed()
     composeTestRule.onAllNodesWithTag("dayRow")[1].assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/PendingMeetingsTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/PendingMeetingsTest.kt
@@ -1,0 +1,2 @@
+package com.swent.suddenbump.ui.calendar
+

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/PendingMeetingsTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/PendingMeetingsTest.kt
@@ -1,2 +1,169 @@
 package com.swent.suddenbump.ui.calendar
 
+import android.location.Location
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.firebase.Timestamp
+import com.swent.suddenbump.model.chat.ChatRepository
+import com.swent.suddenbump.model.meeting.Meeting
+import com.swent.suddenbump.model.meeting.MeetingRepository
+import com.swent.suddenbump.model.meeting.MeetingViewModel
+import com.swent.suddenbump.model.user.User
+import com.swent.suddenbump.model.user.UserRepository
+import com.swent.suddenbump.model.user.UserViewModel
+import com.swent.suddenbump.ui.navigation.NavigationActions
+import com.swent.suddenbump.ui.navigation.Screen
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.*
+
+@RunWith(AndroidJUnit4::class)
+class PendingMeetingsScreenTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
+
+  private lateinit var navigationActions: NavigationActions
+
+  private lateinit var meetingViewModel: MeetingViewModel
+  private lateinit var meetingRepository: MeetingRepository
+
+  private lateinit var userRepository: UserRepository
+  private lateinit var userViewModel: UserViewModel
+  private lateinit var chatRepository: ChatRepository
+
+  @Before
+  fun setUp() {
+    meetingRepository = mock(MeetingRepository::class.java)
+    userRepository = mock(UserRepository::class.java)
+    chatRepository = mock(ChatRepository::class.java)
+    navigationActions = mock(NavigationActions::class.java)
+    meetingViewModel = MeetingViewModel(meetingRepository)
+    userViewModel = UserViewModel(userRepository, chatRepository)
+
+    // Mock StateFlow data for meetings
+    val meetingsFlow =
+        MutableStateFlow(
+            listOf(
+                Meeting("1", "Central Park", Timestamp.now(), "friend1", "creator1", false),
+                Meeting("2", "City Square", Timestamp.now(), "friend1", "creator2", false)))
+    val mockStateFlow = mock(StateFlow::class.java) as StateFlow<List<Meeting>>
+    //        `when`(meetingViewModel.meetings).thenReturn(mockStateFlow)
+    // doReturn(mockStateFlow).`when`(meetingViewModel.meetings)
+    /* `when`(mockStateFlow.value).thenReturn(listOf(
+        Meeting("1", "Central Park", Timestamp.now(), "friend1", "creator1", false),
+        Meeting("2", "City Square", Timestamp.now(), "friend1", "creator2", false)
+    ))*/
+    //        `when`(meetingViewModel.meetings).thenReturn(meetingsFlow)
+
+    // Mock StateFlow data for user friends
+    val userFriendsFlow =
+        MutableStateFlow(
+            listOf(
+                User(
+                    "creator1",
+                    "Mike",
+                    "Tyson",
+                    "12345678",
+                    null,
+                    "user@email.com",
+                    MutableStateFlow(Location("default"))),
+                User(
+                    "creator2",
+                    "Joe",
+                    "Biden",
+                    "12345678",
+                    null,
+                    "user@email.com",
+                    MutableStateFlow(Location("default")))))
+    // `when`(userViewModel.getUserFriends()).thenReturn(userFriendsFlow)
+
+    // Mock StateFlow data for current user
+    val currentUserFlow =
+        MutableStateFlow(
+            User(
+                "friend1",
+                "John",
+                "Doe",
+                "12345678",
+                null,
+                "user@email.com",
+                MutableStateFlow(Location("default"))))
+    // `when`(userViewModel.getCurrentUser()).thenReturn(currentUserFlow)
+
+    // Mock navigation actions
+    `when`(navigationActions.currentRoute()).thenReturn(Screen.PENDING_MEETINGS)
+  }
+
+  @Test
+  fun displayPendingMeetingsScreen() {
+    composeTestRule.setContent {
+      PendingMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
+    }
+
+    // Verify top app bar
+    composeTestRule.onNodeWithTag("Pending Meetings").assertIsDisplayed()
+    composeTestRule.onNodeWithTag("Back").assertIsDisplayed()
+
+    // Verify bottom navigation
+    composeTestRule.onNodeWithTag("pendingMeetingsScreen").assertIsDisplayed()
+
+    // Verify meetings list
+    // composeTestRule.onAllNodesWithTag("pendingMeetingRow").assertCountEquals(2)
+  }
+  /*
+  @Test
+  fun acceptMeeting_callsUpdateMeeting() {
+      composeTestRule.setContent {
+          PendingMeetingsScreen(
+              navigationActions = navigationActions,
+              meetingViewModel = meetingViewModel,
+              userViewModel = userViewModel
+          )
+      }
+
+      // Click accept button
+      composeTestRule.onAllNodesWithTag("acceptButton")[0].performClick()
+
+      // Verify updateMeeting called with correct arguments
+      verify(meetingViewModel).updateMeeting(any())
+  }
+
+  @Test
+  fun declineMeeting_callsDeleteMeeting() {
+      composeTestRule.setContent {
+          PendingMeetingsScreen(
+              navigationActions = navigationActions,
+              meetingViewModel = meetingViewModel,
+              userViewModel = userViewModel
+          )
+      }
+
+      // Click decline button
+      composeTestRule.onAllNodesWithTag("denyButton")[0].performClick()
+
+      // Verify deleteMeeting called with correct arguments
+      verify(meetingViewModel).deleteMeeting(anyOrNull())
+  }
+
+  @Test
+  fun backButton_callsNavigationGoBack() {
+      composeTestRule.setContent {
+          PendingMeetingsScreen(
+              navigationActions = navigationActions,
+              meetingViewModel = meetingViewModel,
+              userViewModel = userViewModel
+          )
+      }
+
+      // Click back button
+      composeTestRule.onNodeWithContentDescription("Back").performClick()
+
+      // Verify goBack called
+      verify(navigationActions).goBack()
+  }*/
+}

--- a/app/src/main/java/com/swent/suddenbump/MainActivity.kt
+++ b/app/src/main/java/com/swent/suddenbump/MainActivity.kt
@@ -42,6 +42,7 @@ import com.swent.suddenbump.ui.authentication.SignUpScreen
 import com.swent.suddenbump.ui.calendar.AddMeetingScreen
 import com.swent.suddenbump.ui.calendar.CalendarMeetingsScreen
 import com.swent.suddenbump.ui.calendar.EditMeetingScreen
+import com.swent.suddenbump.ui.calendar.PendingMeetingsScreen
 import com.swent.suddenbump.ui.chat.ChatScreen
 import com.swent.suddenbump.ui.contact.AddContactScreen
 import com.swent.suddenbump.ui.contact.ContactScreen
@@ -219,6 +220,9 @@ class MainActivity : ComponentActivity() {
           CalendarMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
         }
         composable(Screen.EDIT_MEETING) { EditMeetingScreen(navigationActions, meetingViewModel) }
+          composable(Screen.PENDING_MEETINGS) {
+              PendingMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
+          }
       }
 
       navigation(

--- a/app/src/main/java/com/swent/suddenbump/MainActivity.kt
+++ b/app/src/main/java/com/swent/suddenbump/MainActivity.kt
@@ -220,9 +220,9 @@ class MainActivity : ComponentActivity() {
           CalendarMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
         }
         composable(Screen.EDIT_MEETING) { EditMeetingScreen(navigationActions, meetingViewModel) }
-          composable(Screen.PENDING_MEETINGS) {
-              PendingMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
-          }
+        composable(Screen.PENDING_MEETINGS) {
+          PendingMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
+        }
       }
 
       navigation(

--- a/app/src/main/java/com/swent/suddenbump/model/meeting/Meeting.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/meeting/Meeting.kt
@@ -7,5 +7,6 @@ data class Meeting(
     val location: String = "",
     val date: Timestamp = Timestamp.now(),
     val friendId: String = "",
-    val creatorId: String = ""
+    val creatorId: String = "",
+    val accepted: Boolean = false
 )

--- a/app/src/main/java/com/swent/suddenbump/model/meeting/MeetingRepositoryFirestore.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/meeting/MeetingRepositoryFirestore.kt
@@ -94,7 +94,6 @@ class MeetingRepositoryFirestore(private val db: FirebaseFirestore) : MeetingRep
         "date" to date,
         "friendId" to friendId,
         "creatorId" to creatorId,
-        "accepted" to accepted
-    )
+        "accepted" to accepted)
   }
 }

--- a/app/src/main/java/com/swent/suddenbump/model/meeting/MeetingRepositoryFirestore.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/meeting/MeetingRepositoryFirestore.kt
@@ -93,6 +93,8 @@ class MeetingRepositoryFirestore(private val db: FirebaseFirestore) : MeetingRep
         "location" to location,
         "date" to date,
         "friendId" to friendId,
-        "creatorId" to creatorId)
+        "creatorId" to creatorId,
+        "accepted" to accepted
+    )
   }
 }

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/AddMeeting.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/AddMeeting.kt
@@ -38,7 +38,7 @@ fun AddMeetingScreen(
         TopAppBar(
             title = {
               Text(
-                  "Add Meeting with ${userViewModel.user?.firstName?: ""}",
+                  "Ask ${userViewModel.user?.firstName?: ""} to Meet",
                   color = Color.White,
                   modifier = Modifier.testTag("Add New Meeting"))
             },
@@ -101,7 +101,7 @@ fun AddMeetingScreen(
                     }
                   },
                   modifier = Modifier.fillMaxWidth().testTag("Save Meeting")) {
-                    Text("Save Meeting")
+                    Text("Ask to Meet")
                   }
             }
       })

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/AddMeeting.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/AddMeeting.kt
@@ -89,7 +89,8 @@ fun AddMeetingScreen(
                               friendId = friendId,
                               location = location,
                               date = meetingDate,
-                              creatorId = userViewModel.getCurrentUser().value?.uid ?: "")
+                              creatorId = userViewModel.getCurrentUser().value?.uid ?: "",
+                              accepted = false)
                       meetingViewModel.addMeeting(newMeeting)
                       Toast.makeText(context, "Meeting created successfully", Toast.LENGTH_SHORT)
                           .show()

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/CalendarMeetings.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/CalendarMeetings.kt
@@ -19,10 +19,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
 import com.swent.suddenbump.model.meeting.Meeting
 import com.swent.suddenbump.model.meeting.MeetingViewModel
 import com.swent.suddenbump.model.user.User
@@ -153,63 +155,78 @@ fun DayRow(
     meetingViewModel: MeetingViewModel,
     currentUserId: String
 ) {
-  val dayFormat = SimpleDateFormat("EEE, d", Locale.getDefault())
+    val dayFormat = SimpleDateFormat("EEE, d", Locale.getDefault())
 
-  Column(
-      modifier =
-          Modifier.fillMaxWidth()
-              .padding(8.dp)
-              .background(com.swent.suddenbump.ui.theme.Purple40, MaterialTheme.shapes.medium)
-              .padding(8.dp)
-              .testTag("dayRow")) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+            .background(com.swent.suddenbump.ui.theme.Purple40, MaterialTheme.shapes.medium)
+            .padding(8.dp)
+            .testTag("dayRow")
+    ) {
         Text(
             text = dayFormat.format(day),
             style = MaterialTheme.typography.titleLarge,
             color = Color.White,
-            modifier = Modifier.padding(bottom = 8.dp))
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
 
-        val filteredMeetings =
-            meetings.filter { it.creatorId == currentUserId || it.friendId == currentUserId }
+        val filteredMeetings = meetings.filter { it.creatorId == currentUserId || it.friendId == currentUserId }
 
         if (filteredMeetings.isNotEmpty()) {
-          Column(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
-            filteredMeetings.forEach { meeting ->
-              Card(
-                  modifier =
-                      Modifier.fillMaxWidth()
-                          .padding(8.dp)
-                          .clickable {
-                            meetingViewModel.selectMeeting(meeting)
-                            navigationActions.navigateTo(Screen.EDIT_MEETING)
-                          }
-                          .background(
-                              com.swent.suddenbump.ui.theme.Purple40, MaterialTheme.shapes.medium),
-                  colors =
-                      CardDefaults.cardColors(
-                          containerColor = com.swent.suddenbump.ui.theme.Pink40)) {
-                    val friend =
-                        userFriends.find {
-                          it.uid == meeting.friendId || it.uid == meeting.creatorId
+            Column(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
+                filteredMeetings.forEach { meeting ->
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(8.dp)
+                            .clickable {
+                                meetingViewModel.selectMeeting(meeting)
+                                navigationActions.navigateTo(Screen.EDIT_MEETING)
+                            }
+                            .background(com.swent.suddenbump.ui.theme.Purple40, MaterialTheme.shapes.medium),
+                        colors = CardDefaults.cardColors(containerColor = com.swent.suddenbump.ui.theme.Pink40)
+                    ) {
+                        val friend = userFriends.find { it.uid == meeting.friendId || it.uid == meeting.creatorId }
+                        val friendName = friend?.let { "${it.firstName} ${it.lastName}" } ?: "Unknown Friend"
+                        val formattedDate = formatDate(meeting.date.toDate())
+
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.padding(12.dp)
+                        ) {
+                            AsyncImage(
+                                model = "https://avatar.iran.liara.run/public/42",
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .width(50.dp)
+                                    .height(50.dp)
+                                    .padding(8.dp)
+                                    .testTag("profileImage")
+                            )
+                            Column {
+                                Text(
+                                    text = "Meet $friendName at ${meeting.location}",
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = Color.White,
+                                    modifier = Modifier.testTag("meetText")
+                                )
+                            }
                         }
-                    val friendName =
-                        friend?.let { "${it.firstName} ${it.lastName}" } ?: "Unknown Friend"
-                    val formattedDate = formatDate(meeting.date.toDate())
-                    Text(
-                        text = "Meet $friendName at ${meeting.location}",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = Color.White,
-                        modifier = Modifier.fillMaxWidth().padding(12.dp).testTag("meetText"))
-                  }
+                    }
+                }
             }
-          }
         } else {
-          Text(
-              text = "No meetings for this day",
-              style = MaterialTheme.typography.bodySmall,
-              modifier = Modifier.padding(start = 8.dp),
-              color = Color.White)
+            Text(
+                text = "No meetings for this day",
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(start = 8.dp),
+                color = Color.White
+            )
         }
-      }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/CalendarMeetings.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/CalendarMeetings.kt
@@ -46,7 +46,7 @@ fun CalendarMeetingsScreen(
   val meetings by meetingViewModel.meetings.collectAsState()
   val userFriends by userViewModel.getUserFriends().collectAsState(initial = emptyList())
   val currentUserId = userViewModel.getCurrentUser().value?.uid ?: ""
-    val pendingMeetingsCount = meetings.count { !it.accepted && it.friendId == currentUserId }
+  val pendingMeetingsCount = meetings.count { !it.accepted && it.friendId == currentUserId }
 
   // Log the current user ID
   Log.d("CalendarMeetingsScreen", "Current User ID: $currentUserId")
@@ -117,7 +117,10 @@ fun ScrollableInfiniteTimeline(
         }
   }
 
-  MonthYearHeader(monthYear = visibleMonthYear, navigationActions = navigationActions, pendingMeetingsCount = pendingMeetingsCount)
+  MonthYearHeader(
+      monthYear = visibleMonthYear,
+      navigationActions = navigationActions,
+      pendingMeetingsCount = pendingMeetingsCount)
 
   LazyColumn(
       state = listState,
@@ -155,117 +158,114 @@ fun DayRow(
     meetingViewModel: MeetingViewModel,
     currentUserId: String
 ) {
-    val dayFormat = SimpleDateFormat("EEE, d", Locale.getDefault())
+  val dayFormat = SimpleDateFormat("EEE, d", Locale.getDefault())
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(8.dp)
-            .background(com.swent.suddenbump.ui.theme.Purple40, MaterialTheme.shapes.medium)
-            .padding(8.dp)
-            .testTag("dayRow")
-    ) {
+  Column(
+      modifier =
+          Modifier.fillMaxWidth()
+              .padding(8.dp)
+              .background(com.swent.suddenbump.ui.theme.Purple40, MaterialTheme.shapes.medium)
+              .padding(8.dp)
+              .testTag("dayRow")) {
         Text(
             text = dayFormat.format(day),
             style = MaterialTheme.typography.titleLarge,
             color = Color.White,
-            modifier = Modifier.padding(bottom = 8.dp)
-        )
+            modifier = Modifier.padding(bottom = 8.dp))
 
-        val filteredMeetings = meetings.filter { it.creatorId == currentUserId || it.friendId == currentUserId }
+        val filteredMeetings =
+            meetings.filter { it.creatorId == currentUserId || it.friendId == currentUserId }
 
         if (filteredMeetings.isNotEmpty()) {
-            Column(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
-                filteredMeetings.forEach { meeting ->
-                    Card(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(8.dp)
-                            .clickable {
-                                meetingViewModel.selectMeeting(meeting)
-                                navigationActions.navigateTo(Screen.EDIT_MEETING)
-                            }
-                            .background(com.swent.suddenbump.ui.theme.Purple40, MaterialTheme.shapes.medium),
-                        colors = CardDefaults.cardColors(containerColor = com.swent.suddenbump.ui.theme.Pink40)
-                    ) {
-                        val friend = userFriends.find { it.uid == meeting.friendId || it.uid == meeting.creatorId }
-                        val friendName = friend?.let { "${it.firstName} ${it.lastName}" } ?: "Unknown Friend"
-                        val formattedDate = formatDate(meeting.date.toDate())
-
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.padding(12.dp)
-                        ) {
-                            AsyncImage(
-                                model = "https://avatar.iran.liara.run/public/42",
-                                contentDescription = null,
-                                modifier = Modifier
-                                    .width(50.dp)
-                                    .height(50.dp)
-                                    .padding(8.dp)
-                                    .testTag("profileImage")
-                            )
-                            Column {
-                                Text(
-                                    text = "Meet $friendName at ${meeting.location}",
-                                    style = MaterialTheme.typography.bodyLarge,
-                                    color = Color.White,
-                                    modifier = Modifier.testTag("meetText")
-                                )
-                            }
+          Column(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
+            filteredMeetings.forEach { meeting ->
+              Card(
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .padding(8.dp)
+                          .clickable {
+                            meetingViewModel.selectMeeting(meeting)
+                            navigationActions.navigateTo(Screen.EDIT_MEETING)
+                          }
+                          .background(
+                              com.swent.suddenbump.ui.theme.Purple40, MaterialTheme.shapes.medium),
+                  colors =
+                      CardDefaults.cardColors(
+                          containerColor = com.swent.suddenbump.ui.theme.Pink40)) {
+                    val friend =
+                        userFriends.find {
+                          it.uid == meeting.friendId || it.uid == meeting.creatorId
                         }
-                    }
-                }
+                    val friendName =
+                        friend?.let { "${it.firstName} ${it.lastName}" } ?: "Unknown Friend"
+                    val formattedDate = formatDate(meeting.date.toDate())
+
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(12.dp)) {
+                          AsyncImage(
+                              model = "https://avatar.iran.liara.run/public/42",
+                              contentDescription = null,
+                              modifier =
+                                  Modifier.width(50.dp)
+                                      .height(50.dp)
+                                      .padding(8.dp)
+                                      .testTag("profileImage"))
+                          Column {
+                            Text(
+                                text = "Meet $friendName at ${meeting.location}",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = Color.White,
+                                modifier = Modifier.testTag("meetText"))
+                          }
+                        }
+                  }
             }
+          }
         } else {
-            Text(
-                text = "No meetings for this day",
-                style = MaterialTheme.typography.bodySmall,
-                modifier = Modifier.padding(start = 8.dp),
-                color = Color.White
-            )
+          Text(
+              text = "No meetings for this day",
+              style = MaterialTheme.typography.bodySmall,
+              modifier = Modifier.padding(start = 8.dp),
+              color = Color.White)
         }
-    }
+      }
 }
 
 @Composable
-fun MonthYearHeader(monthYear: String, navigationActions: NavigationActions, pendingMeetingsCount: Int) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp)
-            .testTag("monthYearHeader"),
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
+fun MonthYearHeader(
+    monthYear: String,
+    navigationActions: NavigationActions,
+    pendingMeetingsCount: Int
+) {
+  Row(
+      modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("monthYearHeader"),
+      horizontalArrangement = Arrangement.SpaceBetween) {
         Text(
             text = monthYear,
             style = MaterialTheme.typography.headlineSmall,
             color = Color.White,
-            modifier = Modifier.padding(16.dp).testTag("monthYearHeader")
-        )
+            modifier = Modifier.padding(16.dp).testTag("monthYearHeader"))
         BadgedBox(
             badge = {
-                if (pendingMeetingsCount > 0) {
-                    Badge {
-                        Text(
-                            text = pendingMeetingsCount.toString(),
-                            color = Color.White,
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                    }
+              if (pendingMeetingsCount > 0) {
+                Badge {
+                  Text(
+                      text = pendingMeetingsCount.toString(),
+                      color = Color.White,
+                      style = MaterialTheme.typography.bodySmall)
                 }
-            }
-        )  {
-            IconButton(onClick = { navigationActions.navigateTo(Screen.PENDING_MEETINGS) }) {
+              }
+            }) {
+              IconButton(onClick = { navigationActions.navigateTo(Screen.PENDING_MEETINGS) }) {
                 Icon(
                     imageVector = Icons.Default.Notifications,
                     contentDescription = "Pending Meetings",
-                    tint = Color.White
-                )
+                    tint = Color.White)
+              }
             }
-        }
-    }
+      }
 }
 
 fun generateDayList(startDate: Calendar, endDate: Calendar): List<Calendar> {

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/CalendarMeetings.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/CalendarMeetings.kt
@@ -241,7 +241,8 @@ fun MonthYearHeader(
 ) {
   Row(
       modifier = Modifier.fillMaxWidth().padding(16.dp).testTag("monthYearHeader"),
-      horizontalArrangement = Arrangement.SpaceBetween) {
+      horizontalArrangement = Arrangement.SpaceBetween,
+      verticalAlignment = Alignment.CenterVertically) {
         Text(
             text = monthYear,
             style = MaterialTheme.typography.headlineSmall,

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/PendingMeetings.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/PendingMeetings.kt
@@ -1,0 +1,189 @@
+package com.swent.suddenbump.ui.calendar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.swent.suddenbump.model.meeting.Meeting
+import com.swent.suddenbump.model.meeting.MeetingViewModel
+import com.swent.suddenbump.model.user.User
+import com.swent.suddenbump.model.user.UserViewModel
+import com.swent.suddenbump.ui.navigation.BottomNavigationMenu
+import com.swent.suddenbump.ui.navigation.LIST_TOP_LEVEL_DESTINATION
+import com.swent.suddenbump.ui.navigation.NavigationActions
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PendingMeetingsScreen(
+    navigationActions: NavigationActions,
+    meetingViewModel: MeetingViewModel,
+    userViewModel: UserViewModel
+) {
+    LaunchedEffect(Unit) { meetingViewModel.getMeetings() }
+    val meetings by meetingViewModel.meetings.collectAsState()
+    val userFriends by userViewModel.getUserFriends().collectAsState(initial = emptyList())
+    val currentUserId = userViewModel.getCurrentUser().value?.uid ?: ""
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Pending Meetings", color = Color.White) },
+                navigationIcon = {
+                    IconButton(onClick = { navigationActions.goBack() }) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back", tint = Color.White)
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Black)
+            )
+        },
+        bottomBar = {
+            BottomNavigationMenu(
+                onTabSelect = { route -> navigationActions.navigateTo(route) },
+                tabList = LIST_TOP_LEVEL_DESTINATION,
+                selectedItem = navigationActions.currentRoute(),
+            )
+        },
+        content = { padding ->
+            Column(
+                modifier = Modifier
+                    .padding(padding)
+                    .background(Color.Black)
+                    .fillMaxSize()
+                    .testTag("pendingMeetingsScreen")
+            ) {
+                ScrollablePendingMeetings(
+                    meetings = meetings.filter { !it.accepted && it.friendId == currentUserId },
+                    userFriends = userFriends,
+                    meetingViewModel = meetingViewModel
+                )
+            }
+        }
+    )
+}
+
+@Composable
+fun ScrollablePendingMeetings(
+    meetings: List<Meeting>,
+    userFriends: List<User>,
+    meetingViewModel: MeetingViewModel,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        items(meetings) { meeting ->
+            PendingMeetingRow(
+                meeting = meeting,
+                userFriends = userFriends,
+                meetingViewModel = meetingViewModel
+            )
+        }
+    }
+}
+
+@Composable
+fun PendingMeetingRow(
+    meeting: Meeting,
+    userFriends: List<User>,
+    meetingViewModel: MeetingViewModel
+) {
+    val friend = userFriends.find { it.uid == meeting.friendId || it.uid == meeting.creatorId }
+    val friendName = friend?.let { "${it.firstName} ${it.lastName.first()}." } ?: "Unknown Friend"
+    val formattedDate = formatDate(meeting.date.toDate())
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(Color.White)
+            .padding(16.dp)
+            .testTag("pendingMeetingRow")
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable {
+                    // Handle row click if needed
+                },
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.weight(1f)
+            ) {
+                AsyncImage(
+                    model = "https://avatar.iran.liara.run/public/42",
+                    contentDescription = null,
+                    modifier = Modifier
+                        .width(50.dp)
+                        .height(50.dp)
+                        .padding(8.dp)
+                        .testTag("profileImage")
+                )
+                Column {
+                    Text(
+                        text = friendName,
+                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+                        modifier = Modifier.testTag("userName")
+                    )
+                    Text(
+                        text = "Meet at ${meeting.location} on $formattedDate",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = Color.Gray,
+                        modifier = Modifier.testTag("meetingDetails")
+                    )
+                }
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                IconButton(
+                    onClick = {
+                        val updatedMeeting = meeting.copy(accepted = true)
+                        meetingViewModel.updateMeeting(updatedMeeting)
+                    },
+                    modifier = Modifier.testTag("acceptButton")
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Check,
+                        contentDescription = "Accept",
+                        tint = Color.Green
+                    )
+                }
+                IconButton(
+                    onClick = { meetingViewModel.deleteMeeting(meeting.meetingId) },
+                    modifier = Modifier.testTag("denyButton")
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "Decline",
+                        tint = Color.Red
+                    )
+                }
+            }
+        }
+        HorizontalDivider(
+            color = Color.Gray,
+            thickness = 0.5.dp,
+            modifier = Modifier.padding(vertical = 4.dp).testTag("divider")
+        )
+    }
+}
+

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/PendingMeetings.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/PendingMeetings.kt
@@ -35,46 +35,48 @@ fun PendingMeetingsScreen(
     meetingViewModel: MeetingViewModel,
     userViewModel: UserViewModel
 ) {
-    LaunchedEffect(Unit) { meetingViewModel.getMeetings() }
-    val meetings by meetingViewModel.meetings.collectAsState()
-    val userFriends by userViewModel.getUserFriends().collectAsState(initial = emptyList())
-    val currentUserId = userViewModel.getCurrentUser().value?.uid ?: ""
+  LaunchedEffect(Unit) { meetingViewModel.getMeetings() }
+  val meetings by meetingViewModel.meetings.collectAsState()
+  val userFriends by userViewModel.getUserFriends().collectAsState(initial = emptyList())
+  val currentUserId = userViewModel.getCurrentUser().value?.uid ?: ""
 
-    Scaffold(
-        topBar = {
-            CenterAlignedTopAppBar(
-                title = { Text("Pending Meetings", color = Color.White) },
-                navigationIcon = {
-                    IconButton(onClick = { navigationActions.goBack() }) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Back", tint = Color.White)
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Black)
-            )
-        },
-        bottomBar = {
-            BottomNavigationMenu(
-                onTabSelect = { route -> navigationActions.navigateTo(route) },
-                tabList = LIST_TOP_LEVEL_DESTINATION,
-                selectedItem = navigationActions.currentRoute(),
-            )
-        },
-        content = { padding ->
-            Column(
-                modifier = Modifier
-                    .padding(padding)
+  Scaffold(
+      topBar = {
+        CenterAlignedTopAppBar(
+            title = {
+              Text(
+                  "Pending Meetings",
+                  color = Color.White,
+                  modifier = Modifier.testTag("Pending Meetings"))
+            },
+            navigationIcon = {
+              IconButton(
+                  onClick = { navigationActions.goBack() }, modifier = Modifier.testTag("Back")) {
+                    Icon(Icons.Default.ArrowBack, contentDescription = "Back", tint = Color.White)
+                  }
+            },
+            colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Black))
+      },
+      bottomBar = {
+        BottomNavigationMenu(
+            onTabSelect = { route -> navigationActions.navigateTo(route) },
+            tabList = LIST_TOP_LEVEL_DESTINATION,
+            selectedItem = navigationActions.currentRoute(),
+        )
+      },
+      content = { padding ->
+        Column(
+            modifier =
+                Modifier.padding(padding)
                     .background(Color.Black)
                     .fillMaxSize()
-                    .testTag("pendingMeetingsScreen")
-            ) {
-                ScrollablePendingMeetings(
-                    meetings = meetings.filter { !it.accepted && it.friendId == currentUserId },
-                    userFriends = userFriends,
-                    meetingViewModel = meetingViewModel
-                )
+                    .testTag("pendingMeetingsScreen")) {
+              ScrollablePendingMeetings(
+                  meetings = meetings.filter { !it.accepted && it.friendId == currentUserId },
+                  userFriends = userFriends,
+                  meetingViewModel = meetingViewModel)
             }
-        }
-    )
+      })
 }
 
 @Composable
@@ -83,19 +85,15 @@ fun ScrollablePendingMeetings(
     userFriends: List<User>,
     meetingViewModel: MeetingViewModel,
 ) {
-    LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
-    ) {
+  LazyColumn(
+      modifier = Modifier.fillMaxSize(),
+      contentPadding = PaddingValues(16.dp),
+      verticalArrangement = Arrangement.spacedBy(12.dp)) {
         items(meetings) { meeting ->
-            PendingMeetingRow(
-                meeting = meeting,
-                userFriends = userFriends,
-                meetingViewModel = meetingViewModel
-            )
+          PendingMeetingRow(
+              meeting = meeting, userFriends = userFriends, meetingViewModel = meetingViewModel)
         }
-    }
+      }
 }
 
 @Composable
@@ -104,86 +102,75 @@ fun PendingMeetingRow(
     userFriends: List<User>,
     meetingViewModel: MeetingViewModel
 ) {
-    val friend = userFriends.find { it.uid == meeting.friendId || it.uid == meeting.creatorId }
-    val friendName = friend?.let { "${it.firstName} ${it.lastName.first()}." } ?: "Unknown Friend"
-    val formattedDate = formatDate(meeting.date.toDate())
+  val friend = userFriends.find { it.uid == meeting.friendId || it.uid == meeting.creatorId }
+  val friendName = friend?.let { "${it.firstName} ${it.lastName.first()}." } ?: "Unknown Friend"
+  val formattedDate = formatDate(meeting.date.toDate())
 
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(10.dp))
-            .background(Color.White)
-            .padding(16.dp)
-            .testTag("pendingMeetingRow")
-    ) {
+  Column(
+      modifier =
+          Modifier.fillMaxWidth()
+              .clip(RoundedCornerShape(10.dp))
+              .background(Color.White)
+              .padding(16.dp)
+              .testTag("pendingMeetingRow")) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable {
-                    // Handle row click if needed
+            modifier =
+                Modifier.fillMaxWidth().clickable {
+                  // Handle row click if needed
                 },
             horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.weight(1f)
-            ) {
-                AsyncImage(
-                    model = "https://avatar.iran.liara.run/public/42",
-                    contentDescription = null,
-                    modifier = Modifier
-                        .width(50.dp)
-                        .height(50.dp)
-                        .padding(8.dp)
-                        .testTag("profileImage")
-                )
-                Column {
-                    Text(
-                        text = friendName,
-                        style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                        modifier = Modifier.testTag("userName")
-                    )
-                    Text(
-                        text = "Meet at ${meeting.location} on $formattedDate",
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = Color.Gray,
-                        modifier = Modifier.testTag("meetingDetails")
-                    )
-                }
-            }
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            verticalAlignment = Alignment.CenterVertically) {
+              Row(
+                  horizontalArrangement = Arrangement.spacedBy(8.dp),
+                  verticalAlignment = Alignment.CenterVertically,
+                  modifier = Modifier.weight(1f)) {
+                    AsyncImage(
+                        model = "https://avatar.iran.liara.run/public/42",
+                        contentDescription = null,
+                        modifier =
+                            Modifier.width(50.dp)
+                                .height(50.dp)
+                                .padding(8.dp)
+                                .testTag("profileImage"))
+                    Column {
+                      Text(
+                          text = friendName,
+                          style =
+                              MaterialTheme.typography.titleMedium.copy(
+                                  fontWeight = FontWeight.Bold),
+                          modifier = Modifier.testTag("userName"))
+                      Text(
+                          text = "Meet at ${meeting.location} on $formattedDate",
+                          style = MaterialTheme.typography.bodyMedium,
+                          color = Color.Gray,
+                          modifier = Modifier.testTag("meetingDetails"))
+                    }
+                  }
+              Row(verticalAlignment = Alignment.CenterVertically) {
                 IconButton(
                     onClick = {
-                        val updatedMeeting = meeting.copy(accepted = true)
-                        meetingViewModel.updateMeeting(updatedMeeting)
+                      val updatedMeeting = meeting.copy(accepted = true)
+                      meetingViewModel.updateMeeting(updatedMeeting)
                     },
-                    modifier = Modifier.testTag("acceptButton")
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Check,
-                        contentDescription = "Accept",
-                        tint = Color.Green
-                    )
-                }
+                    modifier = Modifier.testTag("acceptButton")) {
+                      Icon(
+                          imageVector = Icons.Default.Check,
+                          contentDescription = "Accept",
+                          tint = Color.Green)
+                    }
                 IconButton(
                     onClick = { meetingViewModel.deleteMeeting(meeting.meetingId) },
-                    modifier = Modifier.testTag("denyButton")
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Close,
-                        contentDescription = "Decline",
-                        tint = Color.Red
-                    )
-                }
+                    modifier = Modifier.testTag("denyButton")) {
+                      Icon(
+                          imageVector = Icons.Default.Close,
+                          contentDescription = "Decline",
+                          tint = Color.Red)
+                    }
+              }
             }
-        }
         HorizontalDivider(
             color = Color.Gray,
             thickness = 0.5.dp,
-            modifier = Modifier.padding(vertical = 4.dp).testTag("divider")
-        )
-    }
+            modifier = Modifier.padding(vertical = 4.dp).testTag("divider"))
+      }
 }
-

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/PendingMeetings.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/PendingMeetings.kt
@@ -28,6 +28,13 @@ import com.swent.suddenbump.ui.navigation.BottomNavigationMenu
 import com.swent.suddenbump.ui.navigation.LIST_TOP_LEVEL_DESTINATION
 import com.swent.suddenbump.ui.navigation.NavigationActions
 
+/**
+ * Composable function to display the Pending Meetings screen.
+ *
+ * @param navigationActions Actions for navigation.
+ * @param meetingViewModel ViewModel for managing meetings.
+ * @param userViewModel ViewModel for managing user data.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PendingMeetingsScreen(
@@ -79,6 +86,13 @@ fun PendingMeetingsScreen(
       })
 }
 
+/**
+ * Composable function to display a scrollable list of pending meetings.
+ *
+ * @param meetings List of meetings to display.
+ * @param userFriends List of user friends.
+ * @param meetingViewModel ViewModel for managing meetings.
+ */
 @Composable
 fun ScrollablePendingMeetings(
     meetings: List<Meeting>,
@@ -96,6 +110,13 @@ fun ScrollablePendingMeetings(
       }
 }
 
+/**
+ * Composable function to display a single row for a pending meeting.
+ *
+ * @param meeting The meeting data.
+ * @param userFriends List of user friends.
+ * @param meetingViewModel ViewModel for managing meetings.
+ */
 @Composable
 fun PendingMeetingRow(
     meeting: Meeting,

--- a/app/src/main/java/com/swent/suddenbump/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/navigation/NavigationActions.kt
@@ -32,6 +32,7 @@ object Screen {
   const val CHAT = "Chat Page"
   const val ADD_MEETING = "Add Meeting Screen"
   const val EDIT_MEETING = "Edit Meeting Screen"
+  const val PENDING_MEETINGS = "Pending Meetings Screen"
 }
 
 data class TopLevelDestination(val route: String, val icon: ImageVector, val textId: String)

--- a/app/src/test/java/com/swent/suddenbump/model/meeting/MeetingRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/meeting/MeetingRepositoryFirestoreTest.kt
@@ -41,7 +41,8 @@ class MeetingRepositoryFirestoreTest {
           location = "Cafe",
           date = Timestamp.now(),
           friendId = "friendId",
-          creatorId = "creatorId")
+          creatorId = "creatorId",
+          accepted = false)
 
   @Before
   fun setUp() {

--- a/app/src/test/java/com/swent/suddenbump/model/meeting/MeetingViewModelTest.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/meeting/MeetingViewModelTest.kt
@@ -34,7 +34,8 @@ class MeetingViewModelTest {
           location = "Cafe",
           date = Timestamp(Date(1725494400000)),
           friendId = "FPHuqGkCBo7Iinbo5OO9",
-          creatorId = "P7vuP4bbEQB03OSR3QwJ")
+          creatorId = "P7vuP4bbEQB03OSR3QwJ",
+          accepted = false)
 
   @OptIn(ExperimentalCoroutinesApi::class)
   @Before


### PR DESCRIPTION
This PR  introduces significant  the PendingMeetingsScreen with the following additions:

1. Pending Meetings Display:

  Incoming meeting requests now appear in the PendingMeetingsScreen.
  Users can either accept or decline these meetings directly from the screen.

2. Meeting Workflow Improvements:

  When a new meeting is created, it will appear in the PendingMeetingsScreen of the invited user.
  The invited user can access this screen via a new bell icon added to the CalendarMeetingsScreen.
  The bell icon includes a badge indicating the number of pending meetings.

3. Meeting Status Updates:

  If a meeting is accepted, it is added to the calendars of both users.
  If a meeting is declined, it is deleted.

4. New Field in Meeting Class:

  The Meeting class now includes a new 'accepted' field.
  This field tracks whether a meeting is still pending (created but not yet accepted). 

-  A test was also added for  PendingMeetingsScreen. For now the test doesn't check the accept or decline meeting features. Despite hours of effort, mocking the userViewModel functions amd meetingViewModel.meetings still doesn't work as it should. However, I expect to solve this issue in the following weeks, once we set up the firebase emulator which will massively ease up this kind of mock testing.