### PR TITLE
modify viewmodel and repository for keeping phone numbers unique

### DIFF
--- a/app/src/main/java/com/swent/suddenbump/model/user/UserRepository.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/user/UserRepository.kt
@@ -18,6 +18,12 @@ interface UserRepository {
       onFailure: (Exception) -> Unit
   )
 
+  fun verifyUnusedPhoneNumber(
+      phoneNumber: String,
+      onSuccess: (Boolean) -> Unit,
+      onFailure: (Exception) -> Unit
+  )
+
   fun createUserAccount(user: User, onSuccess: () -> Unit, onFailure: (Exception) -> Unit)
 
   fun createFriendRequest(

--- a/app/src/main/java/com/swent/suddenbump/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/user/UserViewModel.kt
@@ -221,6 +221,14 @@ open class UserViewModel(
     repository.verifyNoAccountExists(emailAddress, onSuccess, onFailure)
   }
 
+  fun verifyUnusedPhoneNumber(
+      phoneNumber: String,
+      onSuccess: (Boolean) -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    repository.verifyUnusedPhoneNumber(phoneNumber, onSuccess, onFailure)
+  }
+
   /**
    * Creates a new user account.
    *

--- a/app/src/main/java/com/swent/suddenbump/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/authentication/SignUp.kt
@@ -297,8 +297,23 @@ fun SignUpScreen(navigationActions: NavigationActions, userViewModel: UserViewMo
               // Button to send verification code
               Button(
                   onClick = {
-                    userViewModel.sendVerificationCode(phoneNumber)
-                    isCodeSent = true
+                    userViewModel.verifyUnusedPhoneNumber(
+                        phoneNumber,
+                        onSuccess = { isUnused ->
+                          if (!isUnused) {
+                            Toast.makeText(
+                                    context, "Phone number already in use", Toast.LENGTH_SHORT)
+                                .show()
+                          } else {
+                            userViewModel.sendVerificationCode(phoneNumber)
+                            isCodeSent = true
+                          }
+                        },
+                        onFailure = {
+                          Toast.makeText(
+                                  context, "Failed to verify phone number", Toast.LENGTH_SHORT)
+                              .show()
+                        })
                   },
                   modifier = Modifier.fillMaxWidth().testTag("sendCodeButton").padding(16.dp),
                   colors =


### PR DESCRIPTION
In this PR, I modified the UserViewModel and UserRepositoryFirestore in order to keep phone numbers unique accross the users of the app. I used the new features of the ViewModel to update the sign-up View with extra error handling, Toasts and unicity checks.

Here is a recap of the contents of this PR :

- unicity check for phone number
- new collections/documents on firebase for storing phone numbers
- new tests for viewmodel and repository
- updated view for handling unicity and reuse of phone number
![image](https://github.com/user-attachments/assets/fbb7b0f3-577f-4f43-8709-f2ada538c55e)
