### PR TITLE
Remove lag in Overview screen

### DIFF
--- a/app/src/main/java/com/swent/suddenbump/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/user/UserViewModel.kt
@@ -425,7 +425,6 @@ open class UserViewModel(
   }
 
   fun getRelativeDistance(friend: User): Float {
-    loadFriends()
     val userLocation = _user.value.lastKnownLocation.value
     val friendLocation = friend.lastKnownLocation.value
     if ((userLocation == locationDummy.value || friendLocation == locationDummy.value)) {


### PR DESCRIPTION
Remove loadFriends() in getRelativeDistance because it was called two times in Overview screen and it's not useful anywhere else.