### PR TITLE
write custom toast matcher

### DIFF
--- a/app/src/androidTest/java/com/swent/suddenbump/ui/authentication/SignUpScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/authentication/SignUpScreenTest.kt
@@ -7,15 +7,21 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import com.swent.suddenbump.model.chat.ChatRepository
 import com.swent.suddenbump.model.user.UserRepository
 import com.swent.suddenbump.model.user.UserViewModel
 import com.swent.suddenbump.ui.navigation.NavigationActions
+import com.swent.suddenbump.ui.utils.ToastMatcher
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -147,6 +153,10 @@ class SignUpScreenTest {
     composeTestRule.setContent { SignUpScreen(navigationActions, userViewModel) }
     composeTestRule.onNodeWithTag("phoneField").performTextInput("+41791234567")
     composeTestRule.onNodeWithTag("sendCodeButton").performClick()
+
+    /*onView(withText("Phone number already in use"))
+      .inRoot(ToastMatcher()) // Use the custom ToastMatcher
+      .check(matches(isDisplayed()))*/
     composeTestRule.onNodeWithTag("codeField").assertDoesNotExist()
   }
 }

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/authentication/SignUpScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/authentication/SignUpScreenTest.kt
@@ -7,21 +7,15 @@ import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextClearance
 import androidx.compose.ui.test.performTextInput
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.assertion.ViewAssertions.matches
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
-import androidx.test.espresso.matcher.ViewMatchers.withText
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 import com.swent.suddenbump.model.chat.ChatRepository
 import com.swent.suddenbump.model.user.UserRepository
 import com.swent.suddenbump.model.user.UserViewModel
 import com.swent.suddenbump.ui.navigation.NavigationActions
-import com.swent.suddenbump.ui.utils.ToastMatcher
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -155,8 +149,8 @@ class SignUpScreenTest {
     composeTestRule.onNodeWithTag("sendCodeButton").performClick()
 
     /*onView(withText("Phone number already in use"))
-      .inRoot(ToastMatcher()) // Use the custom ToastMatcher
-      .check(matches(isDisplayed()))*/
+    .inRoot(ToastMatcher()) // Use the custom ToastMatcher
+    .check(matches(isDisplayed()))*/
     composeTestRule.onNodeWithTag("codeField").assertDoesNotExist()
   }
 }

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/utils/ToastMatcher.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/utils/ToastMatcher.kt
@@ -9,23 +9,23 @@ import org.hamcrest.TypeSafeMatcher
 
 class ToastMatcher : TypeSafeMatcher<Root?>() {
 
-    override fun describeTo(description: Description?) {
-        description?.appendText("is toast")
-    }
+  override fun describeTo(description: Description?) {
+    description?.appendText("is toast")
+  }
 
-    override fun matchesSafely(item: Root?): Boolean {
-        val type: Int? = item?.windowLayoutParams?.get()?.type
-        Log.d("ToastMatcher", "Type: $type")
-        if (type == WindowManager.LayoutParams.TYPE_TOAST || type == WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY) {
-            val windowToken: IBinder = item.decorView.windowToken
-            val appToken: IBinder = item.decorView.getApplicationWindowToken()
-            if (windowToken === appToken) { // means this window isn't contained by any other windows.
-                Log.d("ToastMatcher", "Toast detected")
-                return true
-            }
-        }
-        Log.d("ToastMatcher", "Not a toast")
-        return false
+  override fun matchesSafely(item: Root?): Boolean {
+    val type: Int? = item?.windowLayoutParams?.get()?.type
+    Log.d("ToastMatcher", "Type: $type")
+    if (type == WindowManager.LayoutParams.TYPE_TOAST ||
+        type == WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY) {
+      val windowToken: IBinder = item.decorView.windowToken
+      val appToken: IBinder = item.decorView.getApplicationWindowToken()
+      if (windowToken === appToken) { // means this window isn't contained by any other windows.
+        Log.d("ToastMatcher", "Toast detected")
+        return true
+      }
     }
-
+    Log.d("ToastMatcher", "Not a toast")
+    return false
+  }
 }

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/utils/ToastMatcher.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/utils/ToastMatcher.kt
@@ -1,0 +1,31 @@
+package com.swent.suddenbump.ui.utils
+
+import android.os.IBinder
+import android.util.Log
+import android.view.WindowManager
+import androidx.test.espresso.Root
+import org.hamcrest.Description
+import org.hamcrest.TypeSafeMatcher
+
+class ToastMatcher : TypeSafeMatcher<Root?>() {
+
+    override fun describeTo(description: Description?) {
+        description?.appendText("is toast")
+    }
+
+    override fun matchesSafely(item: Root?): Boolean {
+        val type: Int? = item?.windowLayoutParams?.get()?.type
+        Log.d("ToastMatcher", "Type: $type")
+        if (type == WindowManager.LayoutParams.TYPE_TOAST || type == WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY) {
+            val windowToken: IBinder = item.decorView.windowToken
+            val appToken: IBinder = item.decorView.getApplicationWindowToken()
+            if (windowToken === appToken) { // means this window isn't contained by any other windows.
+                Log.d("ToastMatcher", "Toast detected")
+                return true
+            }
+        }
+        Log.d("ToastMatcher", "Not a toast")
+        return false
+    }
+
+}


### PR DESCRIPTION
The ToastMatcher is supposed to be a class that implements TypeSafeMatcher<Root?>. Its purpose is to look through the window hierarchy of the android phone and search for the text of the toast you want to assert existence.

On my side, even though I see the toast displaying in testAlreadyUsedPhoneNumber() (SignUpScreenTest.kt) with the exact same text as the one in the onView call, the window layout params type is 1 (so the application window, and not the overlayed stuff where the Toast should be located).

In other words, root?.windowLayoutParams?.get()?.type should be equal to 2038 here and not 1.

According to the internet, this sometimes happens on the emulator and they recommend testing with a real device. I do not have a real device at hand right now. Could someone test this with their Android phone?