### PR TITLE
255 automaticly delete expired meetings from pendingmeetings

### DIFF
--- a/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/CalendarMeetingsTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/CalendarMeetingsTest.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.test.assertAny
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.hasText
-import com.google.firebase.Timestamp
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
@@ -14,6 +13,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.firebase.Timestamp
 import com.swent.suddenbump.model.meeting.Meeting
 import com.swent.suddenbump.model.meeting.MeetingRepository
 import com.swent.suddenbump.model.meeting.MeetingViewModel
@@ -39,8 +39,7 @@ class CalendarMeetingsScreenTest {
   private lateinit var userViewModel: UserViewModel
   private lateinit var meetingRepository: MeetingRepository
 
-  @get:Rule
-  val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
@@ -50,47 +49,46 @@ class CalendarMeetingsScreenTest {
     meetingViewModel = MeetingViewModel(meetingRepository)
 
     // Mock user data
-    val currentUser = User(
-      uid = "currentUserId",
-      firstName = "Jake",
-      lastName = "Paul",
-      phoneNumber = "+1234567890",
-      profilePicture = null,
-      emailAddress = "current@gmail.com",
-      lastKnownLocation = MutableStateFlow(Location("mock_provider"))
-    )
-    val userFriends = listOf(
-      User(
-        "friendId1",
-        "Mike",
-        "Tyson",
-        "+12345678",
-        null,
-        "mike@example.com",
-        MutableStateFlow(Location("mock_provider"))
-      ),
-      User(
-        "friendId2",
-        "Joe",
-        "Biden",
-        "+123456789",
-        null,
-        "joe@example.com",
-        MutableStateFlow(Location("mock_provider"))
-      )
-    )
+    val currentUser =
+        User(
+            uid = "currentUserId",
+            firstName = "Jake",
+            lastName = "Paul",
+            phoneNumber = "+1234567890",
+            profilePicture = null,
+            emailAddress = "current@gmail.com",
+            lastKnownLocation = MutableStateFlow(Location("mock_provider")))
+    val userFriends =
+        listOf(
+            User(
+                "friendId1",
+                "Mike",
+                "Tyson",
+                "+12345678",
+                null,
+                "mike@example.com",
+                MutableStateFlow(Location("mock_provider"))),
+            User(
+                "friendId2",
+                "Joe",
+                "Biden",
+                "+123456789",
+                null,
+                "joe@example.com",
+                MutableStateFlow(Location("mock_provider"))))
 
     every { userViewModel.getUserFriends() } returns MutableStateFlow(userFriends)
     every { userViewModel.getCurrentUser() } returns MutableStateFlow(currentUser)
     // Mock meeting data
-    val meetings = listOf(
-      Meeting("1", "Central Park", Timestamp.now(), "currentUserId", "friendId1", false),
-      Meeting("2", "City Square", Timestamp.now(), "currentUserId", "friendId2", true)
-    )
-    every { meetingRepository.getMeetings(any(), any()) } answers {
-      val onSuccess = firstArg<(List<Meeting>) -> Unit>()
-      onSuccess(meetings)
-    }
+    val meetings =
+        listOf(
+            Meeting("1", "Central Park", Timestamp.now(), "currentUserId", "friendId1", false),
+            Meeting("2", "City Square", Timestamp.now(), "currentUserId", "friendId2", true))
+    every { meetingRepository.getMeetings(any(), any()) } answers
+        {
+          val onSuccess = firstArg<(List<Meeting>) -> Unit>()
+          onSuccess(meetings)
+        }
 
     // Mock navigation actions
     every { navigationActions.currentRoute() } returns (Route.OVERVIEW)
@@ -119,10 +117,9 @@ class CalendarMeetingsScreenTest {
   fun dayRowDisplaysNoMeetingsMessage() {
     composeTestRule.onAllNodesWithTag("dayRow")[1].assertIsDisplayed()
     composeTestRule
-      .onAllNodesWithText("No meetings for this day")
-      .assertAny(hasText("No meetings for this day"))
+        .onAllNodesWithText("No meetings for this day")
+        .assertAny(hasText("No meetings for this day"))
   }
-
 
   @Test
   fun displaysMeetingsForSpecificDay() {
@@ -130,11 +127,11 @@ class CalendarMeetingsScreenTest {
     composeTestRule.onAllNodesWithTag("dayRow").onFirst().assertIsDisplayed()
 
     // Use `useUnmergedTree` to find the node with `meetText`
-    composeTestRule.onNodeWithTag("meetText", useUnmergedTree = true)
-      .assertIsDisplayed()
-      .assertTextContains("Meet Joe Biden at City Square")
+    composeTestRule
+        .onNodeWithTag("meetText", useUnmergedTree = true)
+        .assertIsDisplayed()
+        .assertTextContains("Meet Joe Biden at City Square")
   }
-
 
   @Test
   fun clickingMeetingNavigatesToEditMeeting() {
@@ -145,11 +142,8 @@ class CalendarMeetingsScreenTest {
     verify(exactly = 1) { navigationActions.navigateTo(Screen.EDIT_MEETING) }
   }
 
-
-
   @Test
-    fun asyncImageIsDisplayedForMeeting() {
-      composeTestRule.onNodeWithTag("profileImage", useUnmergedTree = true).assertIsDisplayed()
-    }
+  fun asyncImageIsDisplayedForMeeting() {
+    composeTestRule.onNodeWithTag("profileImage", useUnmergedTree = true).assertIsDisplayed()
+  }
 }
-

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/CalendarMeetingsTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/CalendarMeetingsTest.kt
@@ -1,48 +1,101 @@
 package com.swent.suddenbump.ui.calendar
 
+import android.location.Location
 import androidx.compose.ui.test.assertAny
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.hasText
+import com.google.firebase.Timestamp
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
-import com.swent.suddenbump.model.chat.ChatRepository
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.swent.suddenbump.model.meeting.Meeting
 import com.swent.suddenbump.model.meeting.MeetingRepository
 import com.swent.suddenbump.model.meeting.MeetingViewModel
-import com.swent.suddenbump.model.user.UserRepository
+import com.swent.suddenbump.model.user.User
 import com.swent.suddenbump.model.user.UserViewModel
 import com.swent.suddenbump.ui.navigation.NavigationActions
 import com.swent.suddenbump.ui.navigation.Route
+import com.swent.suddenbump.ui.navigation.Screen
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.Mock
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
+import org.junit.runner.RunWith
 
-class CalendarMeetingsTest {
+@RunWith(AndroidJUnit4::class)
+class CalendarMeetingsScreenTest {
+
   private lateinit var navigationActions: NavigationActions
-
   private lateinit var meetingViewModel: MeetingViewModel
-  private lateinit var userRepository: UserRepository
+  private lateinit var userViewModel: UserViewModel
   private lateinit var meetingRepository: MeetingRepository
 
-  @Mock private lateinit var userViewModel: UserViewModel
-  @Mock private lateinit var chatRepository: ChatRepository
-
-  @get:Rule val composeTestRule = createComposeRule()
+  @get:Rule
+  val composeTestRule = createComposeRule()
 
   @Before
   fun setUp() {
-    navigationActions = mock(NavigationActions::class.java)
-    userRepository = mock(UserRepository::class.java)
-    chatRepository = mock(ChatRepository::class.java)
-    userViewModel = UserViewModel(userRepository, chatRepository)
-    `when`(navigationActions.currentRoute()).thenReturn(Route.CALENDAR)
-
-    meetingRepository = mock(MeetingRepository::class.java)
+    navigationActions = mockk(relaxed = true)
+    userViewModel = mockk(relaxed = true)
+    meetingRepository = mockk(relaxed = true)
     meetingViewModel = MeetingViewModel(meetingRepository)
+
+    // Mock user data
+    val currentUser = User(
+      uid = "currentUserId",
+      firstName = "Jake",
+      lastName = "Paul",
+      phoneNumber = "+1234567890",
+      profilePicture = null,
+      emailAddress = "current@gmail.com",
+      lastKnownLocation = MutableStateFlow(Location("mock_provider"))
+    )
+    val userFriends = listOf(
+      User(
+        "friendId1",
+        "Mike",
+        "Tyson",
+        "+12345678",
+        null,
+        "mike@example.com",
+        MutableStateFlow(Location("mock_provider"))
+      ),
+      User(
+        "friendId2",
+        "Joe",
+        "Biden",
+        "+123456789",
+        null,
+        "joe@example.com",
+        MutableStateFlow(Location("mock_provider"))
+      )
+    )
+
+    every { userViewModel.getUserFriends() } returns MutableStateFlow(userFriends)
+    every { userViewModel.getCurrentUser() } returns MutableStateFlow(currentUser)
+    // Mock meeting data
+    val meetings = listOf(
+      Meeting("1", "Central Park", Timestamp.now(), "currentUserId", "friendId1", false),
+      Meeting("2", "City Square", Timestamp.now(), "currentUserId", "friendId2", true)
+    )
+    every { meetingRepository.getMeetings(any(), any()) } answers {
+      val onSuccess = firstArg<(List<Meeting>) -> Unit>()
+      onSuccess(meetings)
+    }
+
+    // Mock navigation actions
+    every { navigationActions.currentRoute() } returns (Route.OVERVIEW)
+    every { navigationActions.goBack() } returns Unit
+    every { navigationActions.navigateTo(Screen.EDIT_MEETING) } returns Unit
 
     composeTestRule.setContent {
       CalendarMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
@@ -52,18 +105,51 @@ class CalendarMeetingsTest {
   @Test
   fun hasRequiredComponents() {
     composeTestRule.onNodeWithTag("calendarMeetingsScreen").assertIsDisplayed()
-    composeTestRule.onAllNodesWithTag("monthYearHeader")[0].assertIsDisplayed()
-    composeTestRule.onAllNodesWithTag("monthYearHeader")[1].assertIsDisplayed()
-    composeTestRule.onAllNodesWithTag("dayRow")[0].assertIsDisplayed()
-    composeTestRule.onAllNodesWithTag("dayRow")[1].assertIsDisplayed()
+    composeTestRule.onNodeWithTag("monthYearHeader", useUnmergedTree = true).assertIsDisplayed()
     composeTestRule.onNodeWithTag("bottomNavigationMenu").assertIsDisplayed()
+  }
+
+  @Test
+  fun displaysPendingMeetingsBadgeWithCorrectCount() {
+    val pendingMeetingsCount = 1 // Based on mock data
+    composeTestRule.onNodeWithText(pendingMeetingsCount.toString()).assertIsDisplayed()
   }
 
   @Test
   fun dayRowDisplaysNoMeetingsMessage() {
     composeTestRule.onAllNodesWithTag("dayRow")[1].assertIsDisplayed()
     composeTestRule
-        .onAllNodesWithText("No meetings for this day")
-        .assertAny(hasText("No meetings for this day"))
+      .onAllNodesWithText("No meetings for this day")
+      .assertAny(hasText("No meetings for this day"))
   }
+
+
+  @Test
+  fun displaysMeetingsForSpecificDay() {
+    // Verify that the first dayRow is displayed
+    composeTestRule.onAllNodesWithTag("dayRow").onFirst().assertIsDisplayed()
+
+    // Use `useUnmergedTree` to find the node with `meetText`
+    composeTestRule.onNodeWithTag("meetText", useUnmergedTree = true)
+      .assertIsDisplayed()
+      .assertTextContains("Meet Joe Biden at City Square")
+  }
+
+
+  @Test
+  fun clickingMeetingNavigatesToEditMeeting() {
+    // Simulate clicking a meeting in the first "dayRow"
+    composeTestRule.onAllNodesWithTag("dayRow").onFirst().performClick()
+
+    // Verify the navigation action was triggered
+    verify(exactly = 1) { navigationActions.navigateTo(Screen.EDIT_MEETING) }
+  }
+
+
+
+  @Test
+    fun asyncImageIsDisplayedForMeeting() {
+      composeTestRule.onNodeWithTag("profileImage", useUnmergedTree = true).assertIsDisplayed()
+    }
 }
+

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/PendingMeetingsTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/PendingMeetingsTest.kt
@@ -14,12 +14,12 @@ import com.swent.suddenbump.ui.navigation.NavigationActions
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import java.util.Date
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import java.util.Date
 
 @RunWith(AndroidJUnit4::class)
 class PendingMeetingsScreenTest {
@@ -35,30 +35,58 @@ class PendingMeetingsScreenTest {
 
   @Before
   fun setUp() {
-      navigationActions = mockk(relaxed = true)
-      userViewModel = mockk(relaxed = true)
-      meetingRepository = mockk(relaxed = true)
-      meetingViewModel = MeetingViewModel(meetingRepository)
+    navigationActions = mockk(relaxed = true)
+    userViewModel = mockk(relaxed = true)
+    meetingRepository = mockk(relaxed = true)
+    meetingViewModel = MeetingViewModel(meetingRepository)
 
-      // Mock meetings
-      val meeting1 = Meeting("1", "Central Park", Timestamp(Date(1735403269000)), "currentUserId", "creator1", false)
-      val meeting2 = Meeting("2", "City Square", Timestamp(Date(1735403269000)), "currentUserId", "creator2", true)
+    // Mock meetings
+    val meeting1 =
+        Meeting(
+            "1", "Central Park", Timestamp(Date(1735403269000)), "currentUserId", "creator1", false)
+    val meeting2 =
+        Meeting(
+            "2", "City Square", Timestamp(Date(1735403269000)), "currentUserId", "creator2", true)
 
-      val mockMeetings = listOf(meeting1, meeting2)
+    val mockMeetings = listOf(meeting1, meeting2)
 
-      every { meetingRepository.getMeetings(any(), any()) } answers {
+    every { meetingRepository.getMeetings(any(), any()) } answers
+        {
           val onSuccess = firstArg<(List<Meeting>) -> Unit>()
           onSuccess(mockMeetings)
-      }
+        }
 
-      // Mock user friends and current user
-      val user1 = User("creator1", "Mike", "Tyson", "+12345678", null, "user1@email.com", MutableStateFlow(Location("mock_provider")))
-      val user2 = User("creator2", "Joe", "Biden", "+123456789", null, "user2@email.com", MutableStateFlow(Location("mock_provider")))
+    // Mock user friends and current user
+    val user1 =
+        User(
+            "creator1",
+            "Mike",
+            "Tyson",
+            "+12345678",
+            null,
+            "user1@email.com",
+            MutableStateFlow(Location("mock_provider")))
+    val user2 =
+        User(
+            "creator2",
+            "Joe",
+            "Biden",
+            "+123456789",
+            null,
+            "user2@email.com",
+            MutableStateFlow(Location("mock_provider")))
 
-      every { userViewModel.getUserFriends() } returns MutableStateFlow(listOf(user1, user2))
-      every { userViewModel.getCurrentUser() } returns MutableStateFlow(
-          User("currentUserId", "Jake", "Paul", "+1234567890", null, "current@gmail.com", MutableStateFlow(Location("mock_provider")))
-      )
+    every { userViewModel.getUserFriends() } returns MutableStateFlow(listOf(user1, user2))
+    every { userViewModel.getCurrentUser() } returns
+        MutableStateFlow(
+            User(
+                "currentUserId",
+                "Jake",
+                "Paul",
+                "+1234567890",
+                null,
+                "current@gmail.com",
+                MutableStateFlow(Location("mock_provider"))))
   }
 
   @Test
@@ -78,77 +106,83 @@ class PendingMeetingsScreenTest {
     composeTestRule.onNodeWithTag("pendingMeetingRow").assertIsDisplayed()
   }
 
-    @Test
-    fun acceptMeeting_callsUpdateMeeting() {
-        val meetingAccepted = Meeting("1", "Central Park", Timestamp(Date(1735403269000)), "currentUserId", "creator1", true)
+  @Test
+  fun acceptMeeting_callsUpdateMeeting() {
+    val meetingAccepted =
+        Meeting(
+            "1", "Central Park", Timestamp(Date(1735403269000)), "currentUserId", "creator1", true)
 
-        composeTestRule.setContent {
-            PendingMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
-        }
-        // Verify accept button is displayed
-        composeTestRule.onNodeWithTag("acceptButton").assertIsDisplayed()
+    composeTestRule.setContent {
+      PendingMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
+    }
+    // Verify accept button is displayed
+    composeTestRule.onNodeWithTag("acceptButton").assertIsDisplayed()
 
-        // Simulate clicking the accept button
-        composeTestRule.onNodeWithTag("acceptButton").performClick()
+    // Simulate clicking the accept button
+    composeTestRule.onNodeWithTag("acceptButton").performClick()
 
-        // Verify that updateMeeting was called with the correct arguments
-        verify { meetingRepository.updateMeeting(eq(meetingAccepted), any(), any()) }
+    // Verify that updateMeeting was called with the correct arguments
+    verify { meetingRepository.updateMeeting(eq(meetingAccepted), any(), any()) }
+  }
+
+  @Test
+  fun declineMeeting_callsDeleteMeeting() {
+    composeTestRule.setContent {
+      PendingMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
+    }
+    // Verify deny button is displayed
+    composeTestRule.onNodeWithTag("denyButton").assertIsDisplayed()
+
+    // Simulate clicking the decline button
+    composeTestRule.onNodeWithTag("denyButton").performClick()
+
+    // Verify that deleteMeeting was called with the correct ID
+    verify { meetingRepository.deleteMeetingById(eq("1"), any(), any()) }
+  }
+
+  @Test
+  fun backButton_callsNavigationGoBack() {
+    composeTestRule.setContent {
+      PendingMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
     }
 
-    @Test
-    fun declineMeeting_callsDeleteMeeting() {
-        composeTestRule.setContent {
-            PendingMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
-        }
-        // Verify deny button is displayed
-        composeTestRule.onNodeWithTag("denyButton").assertIsDisplayed()
+    // Simulate clicking the back button
+    composeTestRule.onNodeWithContentDescription("Back").performClick()
 
-        // Simulate clicking the decline button
-        composeTestRule.onNodeWithTag("denyButton").performClick()
+    // Verify that navigationActions.goBack() was called
+    verify { navigationActions.goBack() }
+  }
 
-        // Verify that deleteMeeting was called with the correct ID
-        verify { meetingRepository.deleteMeetingById(eq("1"), any(), any()) }
+  @Test
+  fun pendingMeetingRow_displaysCorrectDetails() {
+    composeTestRule.setContent {
+      PendingMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
     }
 
-    @Test
-    fun backButton_callsNavigationGoBack() {
-        composeTestRule.setContent {
-            PendingMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
-        }
+    // Verify the userName text field
+    composeTestRule
+        .onNodeWithTag("userName", useUnmergedTree = true)
+        .assertExists()
+        .assertTextEquals("Mike T.")
+        .assertIsDisplayed()
 
-        // Simulate clicking the back button
-        composeTestRule.onNodeWithContentDescription("Back").performClick()
+    // Verify the meetingDetails text field
+    composeTestRule
+        .onNodeWithTag("meetingDetails", useUnmergedTree = true)
+        .assertExists()
+        .assertTextEquals("Meet at Central Park on 2024-12-28")
+        .assertIsDisplayed()
 
-        // Verify that navigationActions.goBack() was called
-        verify { navigationActions.goBack() }
-    }
+    // Verify the profile image
+    composeTestRule
+        .onNodeWithTag("profileImage", useUnmergedTree = true)
+        .assertExists()
+        .assertIsDisplayed()
 
-    @Test
-    fun pendingMeetingRow_displaysCorrectDetails() {
-        composeTestRule.setContent {
-            PendingMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
-        }
-
-        // Verify the userName text field
-        composeTestRule.onNodeWithTag("userName", useUnmergedTree = true)
-            .assertExists()
-            .assertTextEquals("Mike T.")
-            .assertIsDisplayed()
-
-        // Verify the meetingDetails text field
-        composeTestRule.onNodeWithTag("meetingDetails", useUnmergedTree = true)
-            .assertExists()
-            .assertTextEquals("Meet at Central Park on 2024-12-28")
-            .assertIsDisplayed()
-
-        // Verify the profile image
-        composeTestRule.onNodeWithTag("profileImage", useUnmergedTree = true)
-            .assertExists()
-            .assertIsDisplayed()
-
-        // Verify the divider
-        composeTestRule.onNodeWithTag("divider", useUnmergedTree = true)
-            .assertExists()
-            .assertIsDisplayed()
-    }
+    // Verify the divider
+    composeTestRule
+        .onNodeWithTag("divider", useUnmergedTree = true)
+        .assertExists()
+        .assertIsDisplayed()
+  }
 }

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/PendingMeetingsTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/PendingMeetingsTest.kt
@@ -5,22 +5,21 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.firebase.Timestamp
-import com.swent.suddenbump.model.chat.ChatRepository
 import com.swent.suddenbump.model.meeting.Meeting
 import com.swent.suddenbump.model.meeting.MeetingRepository
 import com.swent.suddenbump.model.meeting.MeetingViewModel
 import com.swent.suddenbump.model.user.User
-import com.swent.suddenbump.model.user.UserRepository
 import com.swent.suddenbump.model.user.UserViewModel
 import com.swent.suddenbump.ui.navigation.NavigationActions
-import com.swent.suddenbump.ui.navigation.Screen
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito.*
+import java.util.Date
 
 @RunWith(AndroidJUnit4::class)
 class PendingMeetingsScreenTest {
@@ -32,71 +31,34 @@ class PendingMeetingsScreenTest {
   private lateinit var meetingViewModel: MeetingViewModel
   private lateinit var meetingRepository: MeetingRepository
 
-  private lateinit var userRepository: UserRepository
   private lateinit var userViewModel: UserViewModel
-  private lateinit var chatRepository: ChatRepository
 
   @Before
   fun setUp() {
-    meetingRepository = mock(MeetingRepository::class.java)
-    userRepository = mock(UserRepository::class.java)
-    chatRepository = mock(ChatRepository::class.java)
-    navigationActions = mock(NavigationActions::class.java)
-    meetingViewModel = MeetingViewModel(meetingRepository)
-    userViewModel = UserViewModel(userRepository, chatRepository)
+      navigationActions = mockk(relaxed = true)
+      userViewModel = mockk(relaxed = true)
+      meetingRepository = mockk(relaxed = true)
+      meetingViewModel = MeetingViewModel(meetingRepository)
 
-    // Mock StateFlow data for meetings
-    val meetingsFlow =
-        MutableStateFlow(
-            listOf(
-                Meeting("1", "Central Park", Timestamp.now(), "friend1", "creator1", false),
-                Meeting("2", "City Square", Timestamp.now(), "friend1", "creator2", false)))
-    val mockStateFlow = mock(StateFlow::class.java) as StateFlow<List<Meeting>>
-    //        `when`(meetingViewModel.meetings).thenReturn(mockStateFlow)
-    // doReturn(mockStateFlow).`when`(meetingViewModel.meetings)
-    /* `when`(mockStateFlow.value).thenReturn(listOf(
-        Meeting("1", "Central Park", Timestamp.now(), "friend1", "creator1", false),
-        Meeting("2", "City Square", Timestamp.now(), "friend1", "creator2", false)
-    ))*/
-    //        `when`(meetingViewModel.meetings).thenReturn(meetingsFlow)
+      // Mock meetings
+      val meeting1 = Meeting("1", "Central Park", Timestamp(Date(1735403269000)), "currentUserId", "creator1", false)
+      val meeting2 = Meeting("2", "City Square", Timestamp(Date(1735403269000)), "currentUserId", "creator2", true)
 
-    // Mock StateFlow data for user friends
-    val userFriendsFlow =
-        MutableStateFlow(
-            listOf(
-                User(
-                    "creator1",
-                    "Mike",
-                    "Tyson",
-                    "12345678",
-                    null,
-                    "user@email.com",
-                    MutableStateFlow(Location("default"))),
-                User(
-                    "creator2",
-                    "Joe",
-                    "Biden",
-                    "12345678",
-                    null,
-                    "user@email.com",
-                    MutableStateFlow(Location("default")))))
-    // `when`(userViewModel.getUserFriends()).thenReturn(userFriendsFlow)
+      val mockMeetings = listOf(meeting1, meeting2)
 
-    // Mock StateFlow data for current user
-    val currentUserFlow =
-        MutableStateFlow(
-            User(
-                "friend1",
-                "John",
-                "Doe",
-                "12345678",
-                null,
-                "user@email.com",
-                MutableStateFlow(Location("default"))))
-    // `when`(userViewModel.getCurrentUser()).thenReturn(currentUserFlow)
+      every { meetingRepository.getMeetings(any(), any()) } answers {
+          val onSuccess = firstArg<(List<Meeting>) -> Unit>()
+          onSuccess(mockMeetings)
+      }
 
-    // Mock navigation actions
-    `when`(navigationActions.currentRoute()).thenReturn(Screen.PENDING_MEETINGS)
+      // Mock user friends and current user
+      val user1 = User("creator1", "Mike", "Tyson", "+12345678", null, "user1@email.com", MutableStateFlow(Location("mock_provider")))
+      val user2 = User("creator2", "Joe", "Biden", "+123456789", null, "user2@email.com", MutableStateFlow(Location("mock_provider")))
+
+      every { userViewModel.getUserFriends() } returns MutableStateFlow(listOf(user1, user2))
+      every { userViewModel.getCurrentUser() } returns MutableStateFlow(
+          User("currentUserId", "Jake", "Paul", "+1234567890", null, "current@gmail.com", MutableStateFlow(Location("mock_provider")))
+      )
   }
 
   @Test
@@ -113,57 +75,80 @@ class PendingMeetingsScreenTest {
     composeTestRule.onNodeWithTag("pendingMeetingsScreen").assertIsDisplayed()
 
     // Verify meetings list
-    // composeTestRule.onAllNodesWithTag("pendingMeetingRow").assertCountEquals(2)
-  }
-  /*
-  @Test
-  fun acceptMeeting_callsUpdateMeeting() {
-      composeTestRule.setContent {
-          PendingMeetingsScreen(
-              navigationActions = navigationActions,
-              meetingViewModel = meetingViewModel,
-              userViewModel = userViewModel
-          )
-      }
-
-      // Click accept button
-      composeTestRule.onAllNodesWithTag("acceptButton")[0].performClick()
-
-      // Verify updateMeeting called with correct arguments
-      verify(meetingViewModel).updateMeeting(any())
+    composeTestRule.onNodeWithTag("pendingMeetingRow").assertIsDisplayed()
   }
 
-  @Test
-  fun declineMeeting_callsDeleteMeeting() {
-      composeTestRule.setContent {
-          PendingMeetingsScreen(
-              navigationActions = navigationActions,
-              meetingViewModel = meetingViewModel,
-              userViewModel = userViewModel
-          )
-      }
+    @Test
+    fun acceptMeeting_callsUpdateMeeting() {
+        val meetingAccepted = Meeting("1", "Central Park", Timestamp(Date(1735403269000)), "currentUserId", "creator1", true)
 
-      // Click decline button
-      composeTestRule.onAllNodesWithTag("denyButton")[0].performClick()
+        composeTestRule.setContent {
+            PendingMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
+        }
+        // Verify accept button is displayed
+        composeTestRule.onNodeWithTag("acceptButton").assertIsDisplayed()
 
-      // Verify deleteMeeting called with correct arguments
-      verify(meetingViewModel).deleteMeeting(anyOrNull())
-  }
+        // Simulate clicking the accept button
+        composeTestRule.onNodeWithTag("acceptButton").performClick()
 
-  @Test
-  fun backButton_callsNavigationGoBack() {
-      composeTestRule.setContent {
-          PendingMeetingsScreen(
-              navigationActions = navigationActions,
-              meetingViewModel = meetingViewModel,
-              userViewModel = userViewModel
-          )
-      }
+        // Verify that updateMeeting was called with the correct arguments
+        verify { meetingRepository.updateMeeting(eq(meetingAccepted), any(), any()) }
+    }
 
-      // Click back button
-      composeTestRule.onNodeWithContentDescription("Back").performClick()
+    @Test
+    fun declineMeeting_callsDeleteMeeting() {
+        composeTestRule.setContent {
+            PendingMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
+        }
+        // Verify deny button is displayed
+        composeTestRule.onNodeWithTag("denyButton").assertIsDisplayed()
 
-      // Verify goBack called
-      verify(navigationActions).goBack()
-  }*/
+        // Simulate clicking the decline button
+        composeTestRule.onNodeWithTag("denyButton").performClick()
+
+        // Verify that deleteMeeting was called with the correct ID
+        verify { meetingRepository.deleteMeetingById(eq("1"), any(), any()) }
+    }
+
+    @Test
+    fun backButton_callsNavigationGoBack() {
+        composeTestRule.setContent {
+            PendingMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
+        }
+
+        // Simulate clicking the back button
+        composeTestRule.onNodeWithContentDescription("Back").performClick()
+
+        // Verify that navigationActions.goBack() was called
+        verify { navigationActions.goBack() }
+    }
+
+    @Test
+    fun pendingMeetingRow_displaysCorrectDetails() {
+        composeTestRule.setContent {
+            PendingMeetingsScreen(navigationActions, meetingViewModel, userViewModel)
+        }
+
+        // Verify the userName text field
+        composeTestRule.onNodeWithTag("userName", useUnmergedTree = true)
+            .assertExists()
+            .assertTextEquals("Mike T.")
+            .assertIsDisplayed()
+
+        // Verify the meetingDetails text field
+        composeTestRule.onNodeWithTag("meetingDetails", useUnmergedTree = true)
+            .assertExists()
+            .assertTextEquals("Meet at Central Park on 2024-12-28")
+            .assertIsDisplayed()
+
+        // Verify the profile image
+        composeTestRule.onNodeWithTag("profileImage", useUnmergedTree = true)
+            .assertExists()
+            .assertIsDisplayed()
+
+        // Verify the divider
+        composeTestRule.onNodeWithTag("divider", useUnmergedTree = true)
+            .assertExists()
+            .assertIsDisplayed()
+    }
 }

--- a/app/src/main/java/com/swent/suddenbump/model/meeting/MeetingViewModel.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/meeting/MeetingViewModel.kt
@@ -6,11 +6,11 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
+import java.util.Calendar
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import java.util.Calendar
 
 /**
  * ViewModel for managing meetings.
@@ -118,15 +118,13 @@ open class MeetingViewModel(private val repositoryMeeting: MeetingRepository) : 
     selectedMeeting.value = meeting
   }
 
-    /**
-     * Deletes all expired meetings from the repository.
-     */
-    fun deleteExpiredMeetings() {
-        val currentDate = Calendar.getInstance().time
-        meetings.value.forEach { meeting ->
-            if (meeting.date.toDate().before(currentDate)) {
-                deleteMeeting(meeting.meetingId)
-            }
-        }
+  /** Deletes all expired meetings from the repository. */
+  fun deleteExpiredMeetings() {
+    val currentDate = Calendar.getInstance().time
+    meetings.value.forEach { meeting ->
+      if (meeting.date.toDate().before(currentDate)) {
+        deleteMeeting(meeting.meetingId)
+      }
     }
+  }
 }

--- a/app/src/main/java/com/swent/suddenbump/model/meeting/MeetingViewModel.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/meeting/MeetingViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import java.util.Calendar
 
 /**
  * ViewModel for managing meetings.
@@ -116,4 +117,16 @@ open class MeetingViewModel(private val repositoryMeeting: MeetingRepository) : 
   fun selectMeeting(meeting: Meeting) {
     selectedMeeting.value = meeting
   }
+
+    /**
+     * Deletes all expired meetings from the repository.
+     */
+    fun deleteExpiredMeetings() {
+        val currentDate = Calendar.getInstance().time
+        meetings.value.forEach { meeting ->
+            if (meeting.date.toDate().before(currentDate)) {
+                deleteMeeting(meeting.meetingId)
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/CalendarMeetings.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/CalendarMeetings.kt
@@ -42,10 +42,13 @@ fun CalendarMeetingsScreen(
     meetingViewModel: MeetingViewModel,
     userViewModel: UserViewModel
 ) {
-  LaunchedEffect(Unit) { meetingViewModel.getMeetings() }
+  LaunchedEffect(Unit) {
+    meetingViewModel.getMeetings()
+    meetingViewModel.deleteExpiredMeetings()
+  }
   val meetings by meetingViewModel.meetings.collectAsState()
   val userFriends by userViewModel.getUserFriends().collectAsState(initial = emptyList())
-  val currentUserId = userViewModel.getCurrentUser().value?.uid ?: ""
+  val currentUserId = userViewModel.getCurrentUser().value.uid ?: ""
   val pendingMeetingsCount = meetings.count { !it.accepted && it.friendId == currentUserId }
 
   // Log the current user ID
@@ -198,7 +201,6 @@ fun DayRow(
                         }
                     val friendName =
                         friend?.let { "${it.firstName} ${it.lastName}" } ?: "Unknown Friend"
-                    val formattedDate = formatDate(meeting.date.toDate())
 
                     Row(
                         horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/CalendarMeetings.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/CalendarMeetings.kt
@@ -247,7 +247,7 @@ fun MonthYearHeader(
             text = monthYear,
             style = MaterialTheme.typography.headlineSmall,
             color = Color.White,
-            modifier = Modifier.padding(16.dp).testTag("monthYearHeader"))
+            modifier = Modifier.padding(16.dp).testTag("monthYearHeaderText"))
         BadgedBox(
             badge = {
               if (pendingMeetingsCount > 0) {

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/PendingMeetings.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/PendingMeetings.kt
@@ -42,7 +42,10 @@ fun PendingMeetingsScreen(
     meetingViewModel: MeetingViewModel,
     userViewModel: UserViewModel
 ) {
-  LaunchedEffect(Unit) { meetingViewModel.getMeetings() }
+  LaunchedEffect(Unit) {
+      meetingViewModel.getMeetings()
+      meetingViewModel.deleteExpiredMeetings()
+  }
   val meetings by meetingViewModel.meetings.collectAsState()
   val userFriends by userViewModel.getUserFriends().collectAsState(initial = emptyList())
   val currentUserId = userViewModel.getCurrentUser().value?.uid ?: ""

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/PendingMeetings.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/PendingMeetings.kt
@@ -42,10 +42,7 @@ fun PendingMeetingsScreen(
     meetingViewModel: MeetingViewModel,
     userViewModel: UserViewModel
 ) {
-  LaunchedEffect(Unit) {
-    meetingViewModel.getMeetings()
-    meetingViewModel.deleteExpiredMeetings()
-  }
+  LaunchedEffect(Unit) { meetingViewModel.getMeetings() }
   val meetings by meetingViewModel.meetings.collectAsState()
   val userFriends by userViewModel.getUserFriends().collectAsState(initial = emptyList())
   val currentUserId = userViewModel.getCurrentUser().value.uid ?: ""

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/PendingMeetings.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/PendingMeetings.kt
@@ -43,8 +43,8 @@ fun PendingMeetingsScreen(
     userViewModel: UserViewModel
 ) {
   LaunchedEffect(Unit) {
-      meetingViewModel.getMeetings()
-      meetingViewModel.deleteExpiredMeetings()
+    meetingViewModel.getMeetings()
+    meetingViewModel.deleteExpiredMeetings()
   }
   val meetings by meetingViewModel.meetings.collectAsState()
   val userFriends by userViewModel.getUserFriends().collectAsState(initial = emptyList())

--- a/app/src/main/java/com/swent/suddenbump/ui/calendar/PendingMeetings.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/calendar/PendingMeetings.kt
@@ -48,7 +48,7 @@ fun PendingMeetingsScreen(
   }
   val meetings by meetingViewModel.meetings.collectAsState()
   val userFriends by userViewModel.getUserFriends().collectAsState(initial = emptyList())
-  val currentUserId = userViewModel.getCurrentUser().value?.uid ?: ""
+  val currentUserId = userViewModel.getCurrentUser().value.uid ?: ""
 
   Scaffold(
       topBar = {

--- a/app/src/main/java/com/swent/suddenbump/worker/LocationUpdateWorker.kt
+++ b/app/src/main/java/com/swent/suddenbump/worker/LocationUpdateWorker.kt
@@ -16,6 +16,7 @@ import com.swent.suddenbump.model.user.User
 import com.swent.suddenbump.model.user.UserRepositoryFirestore
 import com.swent.suddenbump.ui.calendar.showMeetingScheduledNotification
 import com.swent.suddenbump.ui.map.showFriendNearbyNotification
+import java.util.Calendar
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -87,7 +88,12 @@ class LocationUpdateWorker(
 
           meetingRepository.getMeetings(
               onSuccess = { meetings ->
-                val filteredMeetings = meetings.filter { it.friendId == user.uid && !it.accepted }
+                val filteredMeetings =
+                    meetings.filter {
+                      it.friendId == user.uid &&
+                          !it.accepted &&
+                          it.date.toDate().after(Calendar.getInstance().time)
+                    }
 
                 if (filteredMeetings.isNotEmpty()) {
                   filteredMeetings.forEach { meeting ->

--- a/app/src/test/java/com/swent/suddenbump/model/meeting/MeetingViewModelTest.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/meeting/MeetingViewModelTest.kt
@@ -16,6 +16,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
@@ -85,10 +86,46 @@ class MeetingViewModelTest {
 
   @OptIn(ExperimentalCoroutinesApi::class)
   @Test
-  fun updateMeeting_callsRepositoryUpdate() = runTest {
-    meetingViewModel.updateMeeting(meeting)
+  fun deleteExpiredMeetings_deletesOnlyExpiredMeetings() = runTest {
+    // Create mock meetings: one expired and one not expired
+    val expiredMeeting = Meeting(
+      meetingId = "expiredMeetingId",
+      location = "Park",
+      date = Timestamp(Date(System.currentTimeMillis() - 10000)), // 10 seconds ago
+      friendId = "Friend1",
+      creatorId = "Creator1",
+      accepted = true
+    )
+    val upcomingMeeting = Meeting(
+      meetingId = "upcomingMeetingId",
+      location = "Library",
+      date = Timestamp(Date(System.currentTimeMillis() + 100000)), // 100 seconds ahead
+      friendId = "Friend2",
+      creatorId = "Creator2",
+      accepted = false
+    )
+
+    // Mock the repository's meetings retrieval
+    val mockMeetings = listOf(expiredMeeting, upcomingMeeting)
+    `when`(meetingRepository.getMeetings(any(), any())).thenAnswer { invocation ->
+      val onSuccess = invocation.arguments[0] as (List<Meeting>) -> Unit
+      onSuccess(mockMeetings) // Provide the mock meetings to the success callback
+    }
+
+    // Call getMeetings to populate the _meetings StateFlow
+    meetingViewModel.getMeetings()
+
+    // Call the method under test
+    meetingViewModel.deleteExpiredMeetings()
+
     // Advance the coroutine to ensure it completes
     advanceUntilIdle()
-    verify(meetingRepository).updateMeeting(eq(meeting), any(), any())
+
+    // Verify the expired meeting is deleted
+    verify(meetingRepository).deleteMeetingById(eq("expiredMeetingId"), any(), any())
+
+    // Verify the non-expired meeting is not deleted
+    verify(meetingRepository, never()).deleteMeetingById(eq("upcomingMeetingId"), any(), any())
   }
+
 }

--- a/app/src/test/java/com/swent/suddenbump/model/meeting/MeetingViewModelTest.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/meeting/MeetingViewModelTest.kt
@@ -88,22 +88,22 @@ class MeetingViewModelTest {
   @Test
   fun deleteExpiredMeetings_deletesOnlyExpiredMeetings() = runTest {
     // Create mock meetings: one expired and one not expired
-    val expiredMeeting = Meeting(
-      meetingId = "expiredMeetingId",
-      location = "Park",
-      date = Timestamp(Date(System.currentTimeMillis() - 10000)), // 10 seconds ago
-      friendId = "Friend1",
-      creatorId = "Creator1",
-      accepted = true
-    )
-    val upcomingMeeting = Meeting(
-      meetingId = "upcomingMeetingId",
-      location = "Library",
-      date = Timestamp(Date(System.currentTimeMillis() + 100000)), // 100 seconds ahead
-      friendId = "Friend2",
-      creatorId = "Creator2",
-      accepted = false
-    )
+    val expiredMeeting =
+        Meeting(
+            meetingId = "expiredMeetingId",
+            location = "Park",
+            date = Timestamp(Date(System.currentTimeMillis() - 10000)), // 10 seconds ago
+            friendId = "Friend1",
+            creatorId = "Creator1",
+            accepted = true)
+    val upcomingMeeting =
+        Meeting(
+            meetingId = "upcomingMeetingId",
+            location = "Library",
+            date = Timestamp(Date(System.currentTimeMillis() + 100000)), // 100 seconds ahead
+            friendId = "Friend2",
+            creatorId = "Creator2",
+            accepted = false)
 
     // Mock the repository's meetings retrieval
     val mockMeetings = listOf(expiredMeeting, upcomingMeeting)
@@ -127,5 +127,4 @@ class MeetingViewModelTest {
     // Verify the non-expired meeting is not deleted
     verify(meetingRepository, never()).deleteMeetingById(eq("upcomingMeetingId"), any(), any())
   }
-
 }


### PR DESCRIPTION
🆕 PR Enhancements Overview:

1️⃣ Introduce deleteExpiredMeetings Functionality:

    Added a deleteExpiredMeetings function in the MeetingViewModel.
    This function removes all meetings with a date in the past from Firestore.

2️⃣ Ensure Data Freshness Across Screens:

    Integrated deleteExpiredMeetings in the CalendarMeetingsScreen to ensure:
        The 🛎️ bell icon (pending notifications) reflects only valid meetings, as well as the PendingMeetings screen.
        
    Also, expired meetings do not trigger unnecessary notifications.
  

3️⃣ 📈 Expand Test Coverage:

    Enhanced the test suite for PendingMeetingsScreen and CalendarMeetingsScreen with more detailed and thorough tests.

🎯 Purpose of These Changes:

    🧹 Keep meeting data clean and accurate across the app.
    🚫 Avoid unnecessary notifications for expired meetings.
    🔍 Strengthen reliability through comprehensive testing.