### PR TITLE
Add unblock user page and functions

### DIFF
--- a/app/src/androidTest/java/com/swent/suddenbump/ui/overview/BlockedUsersScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/overview/BlockedUsersScreenTest.kt
@@ -1,0 +1,192 @@
+package com.swent.suddenbump.ui.overview
+
+import android.location.Location
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.swent.suddenbump.model.user.User
+import com.swent.suddenbump.model.user.UserViewModel
+import com.swent.suddenbump.ui.navigation.NavigationActions
+import com.swent.suddenbump.ui.navigation.Route
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class BlockedUsersScreenTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private lateinit var navigationActions: NavigationActions
+    private lateinit var userViewModel: UserViewModel
+    private lateinit var currentUser: User
+    private lateinit var blockedUser1: User
+    private lateinit var blockedUser2: User
+
+    @Before
+    fun setUp() {
+        navigationActions = mockk(relaxed = true)
+        userViewModel = mockk(relaxed = true)
+
+        // Create a mock location
+        val mockLocation = MutableStateFlow(
+            Location("mock_provider").apply {
+                latitude = 46.5180
+                longitude = 6.5680
+            }
+        )
+
+        // Set up test users
+        currentUser = User(
+            uid = "current_user",
+            firstName = "Current",
+            lastName = "User",
+            phoneNumber = "+41789123450",
+            profilePicture = null,
+            emailAddress = "current.user@example.com",
+            lastKnownLocation = mockLocation
+        )
+
+        blockedUser1 = User(
+            uid = "blocked1",
+            firstName = "John",
+            lastName = "Doe",
+            phoneNumber = "+41789123456",
+            profilePicture = null,
+            emailAddress = "john.doe@example.com",
+            lastKnownLocation = mockLocation
+        )
+
+        blockedUser2 = User(
+            uid = "blocked2",
+            firstName = "Jane",
+            lastName = "Smith",
+            phoneNumber = "+41789123457",
+            profilePicture = null,
+            emailAddress = "jane.smith@example.com",
+            lastKnownLocation = mockLocation
+        )
+
+        // Mock navigation and view model responses
+        every { navigationActions.currentRoute() } returns Route.OVERVIEW
+        every { userViewModel.getCurrentUser() } returns MutableStateFlow(currentUser)
+        every { userViewModel.getBlockedFriends() } returns MutableStateFlow(listOf(blockedUser1, blockedUser2))
+    }
+
+    @Test
+    fun testInitialScreenState() {
+        composeTestRule.setContent { 
+            BlockedUsersScreen(navigationActions, userViewModel)
+        }
+
+        // Verify screen is displayed
+        composeTestRule.onNodeWithTag("blockedUsersScreen").assertExists()
+
+        // Verify top bar
+        composeTestRule.onNodeWithText("Blocked Users").assertExists()
+        composeTestRule.onNodeWithTag("backButton").assertExists()
+
+        // Verify blocked users are displayed
+        composeTestRule.onNodeWithText("John Doe").assertExists()
+        composeTestRule.onNodeWithText("Jane Smith").assertExists()
+    }
+
+    @Test
+    fun testEmptyBlockedUsersList() {
+        // Mock empty blocked users list
+        every { userViewModel.getBlockedFriends() } returns MutableStateFlow(emptyList())
+
+        composeTestRule.setContent { 
+            BlockedUsersScreen(navigationActions, userViewModel)
+        }
+
+        // Verify empty state message
+        composeTestRule.onNodeWithText("You haven't blocked any users").assertExists()
+    }
+
+    @Test
+    fun testNavigationBackButton() {
+        composeTestRule.setContent { 
+            BlockedUsersScreen(navigationActions, userViewModel)
+        }
+
+        // Click back button
+        composeTestRule.onNodeWithTag("backButton").performClick()
+
+        // Verify navigation
+        verify { navigationActions.goBack() }
+    }
+
+    @Test
+    fun testUnblockUser() {
+        composeTestRule.setContent { 
+            BlockedUsersScreen(navigationActions, userViewModel)
+        }
+
+        // Click unblock button for the first user
+        composeTestRule.onAllNodesWithTag("unblockButton")[0].performClick()
+
+        // Verify confirmation dialog appears
+        composeTestRule.onNodeWithText("Unblock User").assertExists()
+        composeTestRule.onNodeWithText("Are you sure you want to unblock John Doe?").assertExists()
+    }
+
+    @Test
+    fun testUnblockUserConfirmation() {
+        composeTestRule.setContent { 
+            BlockedUsersScreen(navigationActions, userViewModel)
+        }
+
+        // Click unblock button for the first user
+        composeTestRule.onAllNodesWithTag("unblockButton")[0].performClick()
+
+        // Verify confirmation dialog appears
+        composeTestRule.onNodeWithText("Unblock User").assertExists()
+        composeTestRule.onNodeWithText("Are you sure you want to unblock John Doe?").assertExists()
+
+        // Click 'Yes' to confirm
+        composeTestRule.onNodeWithText("Yes").performClick()
+
+        // Verify unblock action was called
+        verify { userViewModel.unblockUser(blockedUser1, any(), any()) }
+    }
+
+    @Test
+    fun testUnblockUserCancellation() {
+        composeTestRule.setContent { 
+            BlockedUsersScreen(navigationActions, userViewModel)
+        }
+
+        // Click unblock button for the first user
+        composeTestRule.onAllNodesWithTag("unblockButton")[0].performClick()
+
+        // Verify confirmation dialog appears
+        composeTestRule.onNodeWithText("Unblock User").assertExists()
+        composeTestRule.onNodeWithText("Are you sure you want to unblock John Doe?").assertExists()
+
+        // Click 'No' to cancel
+        composeTestRule.onNodeWithText("No").performClick()
+
+        // Verify dialog is dismissed
+        composeTestRule.onNodeWithText("Unblock User").assertDoesNotExist()
+        
+        // Verify unblock was not called
+        verify(exactly = 0) { userViewModel.unblockUser(any(), any(), any()) }
+    }
+
+    @Test
+    fun testBlockedUserItemDisplay() {
+        composeTestRule.setContent { 
+            BlockedUsersScreen(navigationActions, userViewModel)
+        }
+
+        // Verify user items are properly displayed
+        composeTestRule.onAllNodesWithTag("blockedUserItem").assertCountEquals(2)
+        
+        // Verify each user's information is displayed
+        composeTestRule.onNodeWithText("John Doe").assertExists()
+        composeTestRule.onNodeWithText("Jane Smith").assertExists()
+    }
+} 

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/overview/BlockedUsersScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/overview/BlockedUsersScreenTest.kt
@@ -16,177 +16,163 @@ import org.junit.Rule
 import org.junit.Test
 
 class BlockedUsersScreenTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
+  @get:Rule val composeTestRule = createComposeRule()
 
-    private lateinit var navigationActions: NavigationActions
-    private lateinit var userViewModel: UserViewModel
-    private lateinit var currentUser: User
-    private lateinit var blockedUser1: User
-    private lateinit var blockedUser2: User
+  private lateinit var navigationActions: NavigationActions
+  private lateinit var userViewModel: UserViewModel
+  private lateinit var currentUser: User
+  private lateinit var blockedUser1: User
+  private lateinit var blockedUser2: User
 
-    @Before
-    fun setUp() {
-        navigationActions = mockk(relaxed = true)
-        userViewModel = mockk(relaxed = true)
+  @Before
+  fun setUp() {
+    navigationActions = mockk(relaxed = true)
+    userViewModel = mockk(relaxed = true)
 
-        // Create a mock location
-        val mockLocation = MutableStateFlow(
+    // Create a mock location
+    val mockLocation =
+        MutableStateFlow(
             Location("mock_provider").apply {
-                latitude = 46.5180
-                longitude = 6.5680
-            }
-        )
+              latitude = 46.5180
+              longitude = 6.5680
+            })
 
-        // Set up test users
-        currentUser = User(
+    // Set up test users
+    currentUser =
+        User(
             uid = "current_user",
             firstName = "Current",
             lastName = "User",
             phoneNumber = "+41789123450",
             profilePicture = null,
             emailAddress = "current.user@example.com",
-            lastKnownLocation = mockLocation
-        )
+            lastKnownLocation = mockLocation)
 
-        blockedUser1 = User(
+    blockedUser1 =
+        User(
             uid = "blocked1",
             firstName = "John",
             lastName = "Doe",
             phoneNumber = "+41789123456",
             profilePicture = null,
             emailAddress = "john.doe@example.com",
-            lastKnownLocation = mockLocation
-        )
+            lastKnownLocation = mockLocation)
 
-        blockedUser2 = User(
+    blockedUser2 =
+        User(
             uid = "blocked2",
             firstName = "Jane",
             lastName = "Smith",
             phoneNumber = "+41789123457",
             profilePicture = null,
             emailAddress = "jane.smith@example.com",
-            lastKnownLocation = mockLocation
-        )
+            lastKnownLocation = mockLocation)
 
-        // Mock navigation and view model responses
-        every { navigationActions.currentRoute() } returns Route.OVERVIEW
-        every { userViewModel.getCurrentUser() } returns MutableStateFlow(currentUser)
-        every { userViewModel.getBlockedFriends() } returns MutableStateFlow(listOf(blockedUser1, blockedUser2))
-    }
+    // Mock navigation and view model responses
+    every { navigationActions.currentRoute() } returns Route.OVERVIEW
+    every { userViewModel.getCurrentUser() } returns MutableStateFlow(currentUser)
+    every { userViewModel.getBlockedFriends() } returns
+        MutableStateFlow(listOf(blockedUser1, blockedUser2))
+  }
 
-    @Test
-    fun testInitialScreenState() {
-        composeTestRule.setContent { 
-            BlockedUsersScreen(navigationActions, userViewModel)
-        }
+  @Test
+  fun testInitialScreenState() {
+    composeTestRule.setContent { BlockedUsersScreen(navigationActions, userViewModel) }
 
-        // Verify screen is displayed
-        composeTestRule.onNodeWithTag("blockedUsersScreen").assertExists()
+    // Verify screen is displayed
+    composeTestRule.onNodeWithTag("blockedUsersScreen").assertExists()
 
-        // Verify top bar
-        composeTestRule.onNodeWithText("Blocked Users").assertExists()
-        composeTestRule.onNodeWithTag("backButton").assertExists()
+    // Verify top bar
+    composeTestRule.onNodeWithText("Blocked Users").assertExists()
+    composeTestRule.onNodeWithTag("backButton").assertExists()
 
-        // Verify blocked users are displayed
-        composeTestRule.onNodeWithText("John Doe").assertExists()
-        composeTestRule.onNodeWithText("Jane Smith").assertExists()
-    }
+    // Verify blocked users are displayed
+    composeTestRule.onNodeWithText("John Doe").assertExists()
+    composeTestRule.onNodeWithText("Jane Smith").assertExists()
+  }
 
-    @Test
-    fun testEmptyBlockedUsersList() {
-        // Mock empty blocked users list
-        every { userViewModel.getBlockedFriends() } returns MutableStateFlow(emptyList())
+  @Test
+  fun testEmptyBlockedUsersList() {
+    // Mock empty blocked users list
+    every { userViewModel.getBlockedFriends() } returns MutableStateFlow(emptyList())
 
-        composeTestRule.setContent { 
-            BlockedUsersScreen(navigationActions, userViewModel)
-        }
+    composeTestRule.setContent { BlockedUsersScreen(navigationActions, userViewModel) }
 
-        // Verify empty state message
-        composeTestRule.onNodeWithText("You haven't blocked any users").assertExists()
-    }
+    // Verify empty state message
+    composeTestRule.onNodeWithText("You haven't blocked any users").assertExists()
+  }
 
-    @Test
-    fun testNavigationBackButton() {
-        composeTestRule.setContent { 
-            BlockedUsersScreen(navigationActions, userViewModel)
-        }
+  @Test
+  fun testNavigationBackButton() {
+    composeTestRule.setContent { BlockedUsersScreen(navigationActions, userViewModel) }
 
-        // Click back button
-        composeTestRule.onNodeWithTag("backButton").performClick()
+    // Click back button
+    composeTestRule.onNodeWithTag("backButton").performClick()
 
-        // Verify navigation
-        verify { navigationActions.goBack() }
-    }
+    // Verify navigation
+    verify { navigationActions.goBack() }
+  }
 
-    @Test
-    fun testUnblockUser() {
-        composeTestRule.setContent { 
-            BlockedUsersScreen(navigationActions, userViewModel)
-        }
+  @Test
+  fun testUnblockUser() {
+    composeTestRule.setContent { BlockedUsersScreen(navigationActions, userViewModel) }
 
-        // Click unblock button for the first user
-        composeTestRule.onAllNodesWithTag("unblockButton")[0].performClick()
+    // Click unblock button for the first user
+    composeTestRule.onAllNodesWithTag("unblockButton")[0].performClick()
 
-        // Verify confirmation dialog appears
-        composeTestRule.onNodeWithText("Unblock User").assertExists()
-        composeTestRule.onNodeWithText("Are you sure you want to unblock John Doe?").assertExists()
-    }
+    // Verify confirmation dialog appears
+    composeTestRule.onNodeWithText("Unblock User").assertExists()
+    composeTestRule.onNodeWithText("Are you sure you want to unblock John Doe?").assertExists()
+  }
 
-    @Test
-    fun testUnblockUserConfirmation() {
-        composeTestRule.setContent { 
-            BlockedUsersScreen(navigationActions, userViewModel)
-        }
+  @Test
+  fun testUnblockUserConfirmation() {
+    composeTestRule.setContent { BlockedUsersScreen(navigationActions, userViewModel) }
 
-        // Click unblock button for the first user
-        composeTestRule.onAllNodesWithTag("unblockButton")[0].performClick()
+    // Click unblock button for the first user
+    composeTestRule.onAllNodesWithTag("unblockButton")[0].performClick()
 
-        // Verify confirmation dialog appears
-        composeTestRule.onNodeWithText("Unblock User").assertExists()
-        composeTestRule.onNodeWithText("Are you sure you want to unblock John Doe?").assertExists()
+    // Verify confirmation dialog appears
+    composeTestRule.onNodeWithText("Unblock User").assertExists()
+    composeTestRule.onNodeWithText("Are you sure you want to unblock John Doe?").assertExists()
 
-        // Click 'Yes' to confirm
-        composeTestRule.onNodeWithText("Yes").performClick()
+    // Click 'Yes' to confirm
+    composeTestRule.onNodeWithText("Yes").performClick()
 
-        // Verify unblock action was called
-        verify { userViewModel.unblockUser(blockedUser1, any(), any()) }
-    }
+    // Verify unblock action was called
+    verify { userViewModel.unblockUser(blockedUser1, any(), any()) }
+  }
 
-    @Test
-    fun testUnblockUserCancellation() {
-        composeTestRule.setContent { 
-            BlockedUsersScreen(navigationActions, userViewModel)
-        }
+  @Test
+  fun testUnblockUserCancellation() {
+    composeTestRule.setContent { BlockedUsersScreen(navigationActions, userViewModel) }
 
-        // Click unblock button for the first user
-        composeTestRule.onAllNodesWithTag("unblockButton")[0].performClick()
+    // Click unblock button for the first user
+    composeTestRule.onAllNodesWithTag("unblockButton")[0].performClick()
 
-        // Verify confirmation dialog appears
-        composeTestRule.onNodeWithText("Unblock User").assertExists()
-        composeTestRule.onNodeWithText("Are you sure you want to unblock John Doe?").assertExists()
+    // Verify confirmation dialog appears
+    composeTestRule.onNodeWithText("Unblock User").assertExists()
+    composeTestRule.onNodeWithText("Are you sure you want to unblock John Doe?").assertExists()
 
-        // Click 'No' to cancel
-        composeTestRule.onNodeWithText("No").performClick()
+    // Click 'No' to cancel
+    composeTestRule.onNodeWithText("No").performClick()
 
-        // Verify dialog is dismissed
-        composeTestRule.onNodeWithText("Unblock User").assertDoesNotExist()
-        
-        // Verify unblock was not called
-        verify(exactly = 0) { userViewModel.unblockUser(any(), any(), any()) }
-    }
+    // Verify dialog is dismissed
+    composeTestRule.onNodeWithText("Unblock User").assertDoesNotExist()
 
-    @Test
-    fun testBlockedUserItemDisplay() {
-        composeTestRule.setContent { 
-            BlockedUsersScreen(navigationActions, userViewModel)
-        }
+    // Verify unblock was not called
+    verify(exactly = 0) { userViewModel.unblockUser(any(), any(), any()) }
+  }
 
-        // Verify user items are properly displayed
-        composeTestRule.onAllNodesWithTag("blockedUserItem").assertCountEquals(2)
-        
-        // Verify each user's information is displayed
-        composeTestRule.onNodeWithText("John Doe").assertExists()
-        composeTestRule.onNodeWithText("Jane Smith").assertExists()
-    }
-} 
+  @Test
+  fun testBlockedUserItemDisplay() {
+    composeTestRule.setContent { BlockedUsersScreen(navigationActions, userViewModel) }
+
+    // Verify user items are properly displayed
+    composeTestRule.onAllNodesWithTag("blockedUserItem").assertCountEquals(2)
+
+    // Verify each user's information is displayed
+    composeTestRule.onNodeWithText("John Doe").assertExists()
+    composeTestRule.onNodeWithText("Jane Smith").assertExists()
+  }
+}

--- a/app/src/main/java/com/swent/suddenbump/MainActivity.kt
+++ b/app/src/main/java/com/swent/suddenbump/MainActivity.kt
@@ -53,6 +53,7 @@ import com.swent.suddenbump.ui.navigation.NavigationActions
 import com.swent.suddenbump.ui.navigation.Route
 import com.swent.suddenbump.ui.navigation.Screen
 import com.swent.suddenbump.ui.overview.AccountScreen
+import com.swent.suddenbump.ui.overview.BlockedUsersScreen
 import com.swent.suddenbump.ui.overview.ConfidentialityScreen
 import com.swent.suddenbump.ui.overview.ConversationScreen
 import com.swent.suddenbump.ui.overview.DiscussionScreen
@@ -264,6 +265,7 @@ class MainActivity : ComponentActivity() {
         ConfidentialityScreen(navigationActions, userViewModel = userViewModel)
       }
       composable("DiscussionsScreen") { DiscussionScreen(navigationActions, userViewModel) }
+      composable("BlockedUsersScreen") { BlockedUsersScreen(navigationActions, userViewModel) }
     }
   }
 }

--- a/app/src/main/java/com/swent/suddenbump/model/user/UserRepository.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/user/UserRepository.kt
@@ -189,6 +189,13 @@ interface UserRepository {
       onSuccess: (List<User>) -> Unit,
       onFailure: (Exception) -> Unit
   )
+
+  fun unblockUser(
+      currentUserId: String,
+      blockedUserId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  )
 }
 
 data class UserWithFriendsInCommon(val user: User, val friendsInCommon: Int)

--- a/app/src/main/java/com/swent/suddenbump/model/user/UserRepositoryFirestore.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/user/UserRepositoryFirestore.kt
@@ -1296,6 +1296,35 @@ class UserRepositoryFirestore(private val db: FirebaseFirestore, private val con
     }
     return userList
   }
+
+  override fun unblockUser(
+      currentUserId: String,
+      blockedUserId: String,
+      onSuccess: () -> Unit,
+      onFailure: (Exception) -> Unit
+  ) {
+    db.collection(usersCollectionPath)
+        .document(currentUserId)
+        .get()
+        .addOnSuccessListener { document ->
+          val blockedList = document.get("blockedList") as? List<String> ?: listOf()
+          val updatedBlockedList = blockedList.filter { it != blockedUserId }
+          
+          // Update the blocked list in Firestore
+          db.collection(usersCollectionPath)
+              .document(currentUserId)
+              .update("blockedList", updatedBlockedList)
+              .addOnSuccessListener {
+                onSuccess()
+              }
+              .addOnFailureListener { e ->
+                onFailure(e)
+              }
+        }
+        .addOnFailureListener { e ->
+          onFailure(e)
+        }
+  }
 }
 
 /**

--- a/app/src/main/java/com/swent/suddenbump/model/user/UserRepositoryFirestore.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/user/UserRepositoryFirestore.kt
@@ -1309,21 +1309,15 @@ class UserRepositoryFirestore(private val db: FirebaseFirestore, private val con
         .addOnSuccessListener { document ->
           val blockedList = document.get("blockedList") as? List<String> ?: listOf()
           val updatedBlockedList = blockedList.filter { it != blockedUserId }
-          
+
           // Update the blocked list in Firestore
           db.collection(usersCollectionPath)
               .document(currentUserId)
               .update("blockedList", updatedBlockedList)
-              .addOnSuccessListener {
-                onSuccess()
-              }
-              .addOnFailureListener { e ->
-                onFailure(e)
-              }
+              .addOnSuccessListener { onSuccess() }
+              .addOnFailureListener { e -> onFailure(e) }
         }
-        .addOnFailureListener { e ->
-          onFailure(e)
-        }
+        .addOnFailureListener { e -> onFailure(e) }
   }
 }
 

--- a/app/src/main/java/com/swent/suddenbump/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/user/UserViewModel.kt
@@ -733,8 +733,7 @@ open class UserViewModel(
             _blockedFriends.value = _blockedFriends.value.filter { it.uid != blockedUser.uid }
             onSuccess()
           },
-          onFailure = onFailure
-      )
+          onFailure = onFailure)
     }
   }
 }

--- a/app/src/main/java/com/swent/suddenbump/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/user/UserViewModel.kt
@@ -718,4 +718,23 @@ open class UserViewModel(
   ) {
     repository.getSharedByFriends(uid, onSuccess, onFailure)
   }
+
+  fun unblockUser(
+      blockedUser: User,
+      onSuccess: () -> Unit = {},
+      onFailure: (Exception) -> Unit = {}
+  ) {
+    viewModelScope.launch {
+      repository.unblockUser(
+          currentUserId = _user.value.uid,
+          blockedUserId = blockedUser.uid,
+          onSuccess = {
+            // Remove user from blocked list in local state
+            _blockedFriends.value = _blockedFriends.value.filter { it.uid != blockedUser.uid }
+            onSuccess()
+          },
+          onFailure = onFailure
+      )
+    }
+  }
 }

--- a/app/src/main/java/com/swent/suddenbump/ui/overview/BlockedUsersScreen.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/overview/BlockedUsersScreen.kt
@@ -154,7 +154,7 @@ private fun BlockedUserItem(user: User, onUnblock: (User) -> Unit) {
               Button(
                   onClick = { showConfirmDialog = true },
                   colors = ButtonDefaults.buttonColors(containerColor = Purple40),
-                  modifier = Modifier.testTag("unblockButton_${user.uid}")) {
+                  modifier = Modifier.testTag("unblockButton")) {
                     Text("Unblock")
                   }
             }

--- a/app/src/main/java/com/swent/suddenbump/ui/overview/BlockedUsersScreen.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/overview/BlockedUsersScreen.kt
@@ -1,6 +1,6 @@
 package com.swent.suddenbump.ui.overview
 
-import android.location.Location
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -32,219 +33,162 @@ import com.swent.suddenbump.model.user.User
 import com.swent.suddenbump.model.user.UserViewModel
 import com.swent.suddenbump.ui.navigation.NavigationActions
 import com.swent.suddenbump.ui.theme.Purple40
-import kotlinx.coroutines.flow.MutableStateFlow
-import android.util.Log
-import androidx.compose.runtime.collectAsState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun BlockedUsersScreen(
-    navigationActions: NavigationActions,
-    userViewModel: UserViewModel
-) {
-    val blockedUsers = userViewModel.getBlockedFriends().collectAsState()
+fun BlockedUsersScreen(navigationActions: NavigationActions, userViewModel: UserViewModel) {
+  val blockedUsers = userViewModel.getBlockedFriends().collectAsState()
 
-    Scaffold(
-        modifier = Modifier.testTag("blockedUsersScreen"),
-        topBar = {
-            CenterAlignedTopAppBar(
-                title = { Text("Blocked Users", maxLines = 1, overflow = TextOverflow.Ellipsis) },
-                navigationIcon = {
-                    IconButton(
-                        onClick = { navigationActions.goBack() },
-                        modifier = Modifier.testTag("backButton")
-                    ) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Go back"
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
+  Scaffold(
+      modifier = Modifier.testTag("blockedUsersScreen"),
+      topBar = {
+        CenterAlignedTopAppBar(
+            title = { Text("Blocked Users", maxLines = 1, overflow = TextOverflow.Ellipsis) },
+            navigationIcon = {
+              IconButton(
+                  onClick = { navigationActions.goBack() },
+                  modifier = Modifier.testTag("backButton")) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Go back")
+                  }
+            },
+            colors =
+                TopAppBarDefaults.topAppBarColors(
                     containerColor = Color.Black,
                     titleContentColor = Color.White,
-                    navigationIconContentColor = Color.White
-                )
-            )
-        }
-    ) { paddingValues ->
+                    navigationIconContentColor = Color.White))
+      }) { paddingValues ->
         Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(Color.Black)
-                .padding(paddingValues)
-                .padding(16.dp)
-        ) {
-            if (blockedUsers.value.isEmpty()) {
+            modifier =
+                Modifier.fillMaxSize()
+                    .background(Color.Black)
+                    .padding(paddingValues)
+                    .padding(16.dp)) {
+              if (blockedUsers.value.isEmpty()) {
                 EmptyBlockedUsersMessage()
-            } else {
+              } else {
                 BlockedUsersList(
                     blockedUsers = blockedUsers.value,
                     onUnblock = { user ->
-                        userViewModel.unblockUser(
-                            blockedUser = user,
-                            onSuccess = {
-                                // The list will be automatically updated through the StateFlow
-                            },
-                            onFailure = { exception ->
-                                Log.e("BlockedUsersScreen", "Failed to unblock user: ${exception.message}")
-                                // You might want to show an error message to the user here
-                            }
-                        )
-                    }
-                )
+                      userViewModel.unblockUser(
+                          blockedUser = user,
+                          onSuccess = {
+                            // The list will be automatically updated through the StateFlow
+                          },
+                          onFailure = { exception ->
+                            Log.e(
+                                "BlockedUsersScreen",
+                                "Failed to unblock user: ${exception.message}")
+                            // You might want to show an error message to the user here
+                          })
+                    })
+              }
             }
-        }
-    }
+      }
 }
 
 @Composable
 private fun EmptyBlockedUsersMessage() {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(
-            text = "You haven't blocked any users",
-            style = MaterialTheme.typography.bodyLarge.copy(
-                fontSize = 18.sp,
-                fontWeight = FontWeight.Medium,
-                color = Color.White
-            ),
-            modifier = Modifier.testTag("emptyBlockedUsersMessage")
-        )
-    }
+  Box(modifier = Modifier.fillMaxSize().padding(16.dp), contentAlignment = Alignment.Center) {
+    Text(
+        text = "You haven't blocked any users",
+        style =
+            MaterialTheme.typography.bodyLarge.copy(
+                fontSize = 18.sp, fontWeight = FontWeight.Medium, color = Color.White),
+        modifier = Modifier.testTag("emptyBlockedUsersMessage"))
+  }
 }
 
 @Composable
-private fun BlockedUsersList(
-    blockedUsers: List<User>,
-    onUnblock: (User) -> Unit
-) {
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(16.dp)
-            .testTag("blockedUsersList"),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        items(blockedUsers) { user ->
-            BlockedUserItem(user = user, onUnblock = onUnblock)
-        }
-    }
+private fun BlockedUsersList(blockedUsers: List<User>, onUnblock: (User) -> Unit) {
+  LazyColumn(
+      modifier = Modifier.fillMaxSize().padding(16.dp).testTag("blockedUsersList"),
+      verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        items(blockedUsers) { user -> BlockedUserItem(user = user, onUnblock = onUnblock) }
+      }
 }
 
 @Composable
-private fun BlockedUserItem(
-    user: User,
-    onUnblock: (User) -> Unit
-) {
-    var showConfirmDialog by remember { mutableStateOf(false) }
+private fun BlockedUserItem(user: User, onUnblock: (User) -> Unit) {
+  var showConfirmDialog by remember { mutableStateOf(false) }
 
-    Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .testTag("blockedUserItem"),
-        shape = RoundedCornerShape(8.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.White)
-    ) {
+  Card(
+      modifier = Modifier.fillMaxWidth().testTag("blockedUserItem"),
+      shape = RoundedCornerShape(8.dp),
+      colors = CardDefaults.cardColors(containerColor = Color.White)) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(8.dp),
+            modifier = Modifier.fillMaxWidth().padding(8.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                // Profile Picture
-                Box(
-                    modifier = Modifier
-                        .size(50.dp)
-                        .clip(CircleShape)
-                        .background(Color.Gray)
-                ) {
-                    if (user.profilePicture != null) {
+            horizontalArrangement = Arrangement.SpaceBetween) {
+              Row(
+                  verticalAlignment = Alignment.CenterVertically,
+                  horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    // Profile Picture
+                    Box(modifier = Modifier.size(50.dp).clip(CircleShape).background(Color.Gray)) {
+                      if (user.profilePicture != null) {
                         Image(
                             bitmap = user.profilePicture,
                             contentDescription = "Profile picture of ${user.firstName}",
                             contentScale = ContentScale.Crop,
-                            modifier = Modifier.fillMaxSize()
-                        )
-                    } else {
+                            modifier = Modifier.fillMaxSize())
+                      } else {
                         Image(
                             painter = painterResource(id = R.drawable.settings_user),
                             contentDescription = "Default profile picture",
                             contentScale = ContentScale.Crop,
-                            modifier = Modifier.fillMaxSize()
-                        )
+                            modifier = Modifier.fillMaxSize())
+                      }
                     }
-                }
 
-                // User Name
-                Column {
-                    Text(
-                        text = "${user.firstName} ${user.lastName}",
-                        style = MaterialTheme.typography.bodyLarge.copy(
-                            fontWeight = FontWeight.Bold
-                        )
-                    )
-                }
-            }
+                    // User Name
+                    Column {
+                      Text(
+                          text = "${user.firstName} ${user.lastName}",
+                          style =
+                              MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold))
+                    }
+                  }
 
-            // Unblock Button
-            Button(
-                onClick = { showConfirmDialog = true },
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = Purple40
-                ),
-                modifier = Modifier.testTag("unblockButton_${user.uid}")
-            ) {
-                Text("Unblock")
+              // Unblock Button
+              Button(
+                  onClick = { showConfirmDialog = true },
+                  colors = ButtonDefaults.buttonColors(containerColor = Purple40),
+                  modifier = Modifier.testTag("unblockButton_${user.uid}")) {
+                    Text("Unblock")
+                  }
             }
-        }
-    }
+      }
 
-    if (showConfirmDialog) {
-        AlertDialog(
-            onDismissRequest = { showConfirmDialog = false },
-            title = {
-                Text(
-                    text = "Unblock User",
-                    style = MaterialTheme.typography.headlineSmall.copy(
-                        fontWeight = FontWeight.Bold
-                    )
-                )
-            },
-            text = {
-                Text(
-                    text = "Are you sure you want to unblock ${user.firstName} ${user.lastName}?",
-                    style = MaterialTheme.typography.bodyLarge
-                )
-            },
-            confirmButton = {
-                Button(
-                    onClick = {
-                        onUnblock(user)
-                        showConfirmDialog = false
-                    },
-                    colors = ButtonDefaults.buttonColors(containerColor = Purple40)
-                ) {
-                    Text("Yes")
-                }
-            },
-            dismissButton = {
-                Button(
-                    onClick = { showConfirmDialog = false },
-                    colors = ButtonDefaults.buttonColors(containerColor = Color.Gray)
-                ) {
-                    Text("No")
-                }
-            }
-        )
-    }
-} 
+  if (showConfirmDialog) {
+    AlertDialog(
+        onDismissRequest = { showConfirmDialog = false },
+        title = {
+          Text(
+              text = "Unblock User",
+              style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold))
+        },
+        text = {
+          Text(
+              text = "Are you sure you want to unblock ${user.firstName} ${user.lastName}?",
+              style = MaterialTheme.typography.bodyLarge)
+        },
+        confirmButton = {
+          Button(
+              onClick = {
+                onUnblock(user)
+                showConfirmDialog = false
+              },
+              colors = ButtonDefaults.buttonColors(containerColor = Purple40)) {
+                Text("Yes")
+              }
+        },
+        dismissButton = {
+          Button(
+              onClick = { showConfirmDialog = false },
+              colors = ButtonDefaults.buttonColors(containerColor = Color.Gray)) {
+                Text("No")
+              }
+        })
+  }
+}

--- a/app/src/main/java/com/swent/suddenbump/ui/overview/BlockedUsersScreen.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/overview/BlockedUsersScreen.kt
@@ -1,0 +1,250 @@
+package com.swent.suddenbump.ui.overview
+
+import android.location.Location
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.swent.suddenbump.R
+import com.swent.suddenbump.model.user.User
+import com.swent.suddenbump.model.user.UserViewModel
+import com.swent.suddenbump.ui.navigation.NavigationActions
+import com.swent.suddenbump.ui.theme.Purple40
+import kotlinx.coroutines.flow.MutableStateFlow
+import android.util.Log
+import androidx.compose.runtime.collectAsState
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BlockedUsersScreen(
+    navigationActions: NavigationActions,
+    userViewModel: UserViewModel
+) {
+    val blockedUsers = userViewModel.getBlockedFriends().collectAsState()
+
+    Scaffold(
+        modifier = Modifier.testTag("blockedUsersScreen"),
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Blocked Users", maxLines = 1, overflow = TextOverflow.Ellipsis) },
+                navigationIcon = {
+                    IconButton(
+                        onClick = { navigationActions.goBack() },
+                        modifier = Modifier.testTag("backButton")
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Go back"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color.Black,
+                    titleContentColor = Color.White,
+                    navigationIconContentColor = Color.White
+                )
+            )
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black)
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            if (blockedUsers.value.isEmpty()) {
+                EmptyBlockedUsersMessage()
+            } else {
+                BlockedUsersList(
+                    blockedUsers = blockedUsers.value,
+                    onUnblock = { user ->
+                        userViewModel.unblockUser(
+                            blockedUser = user,
+                            onSuccess = {
+                                // The list will be automatically updated through the StateFlow
+                            },
+                            onFailure = { exception ->
+                                Log.e("BlockedUsersScreen", "Failed to unblock user: ${exception.message}")
+                                // You might want to show an error message to the user here
+                            }
+                        )
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyBlockedUsersMessage() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "You haven't blocked any users",
+            style = MaterialTheme.typography.bodyLarge.copy(
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Medium,
+                color = Color.White
+            ),
+            modifier = Modifier.testTag("emptyBlockedUsersMessage")
+        )
+    }
+}
+
+@Composable
+private fun BlockedUsersList(
+    blockedUsers: List<User>,
+    onUnblock: (User) -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+            .testTag("blockedUsersList"),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        items(blockedUsers) { user ->
+            BlockedUserItem(user = user, onUnblock = onUnblock)
+        }
+    }
+}
+
+@Composable
+private fun BlockedUserItem(
+    user: User,
+    onUnblock: (User) -> Unit
+) {
+    var showConfirmDialog by remember { mutableStateOf(false) }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("blockedUserItem"),
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                // Profile Picture
+                Box(
+                    modifier = Modifier
+                        .size(50.dp)
+                        .clip(CircleShape)
+                        .background(Color.Gray)
+                ) {
+                    if (user.profilePicture != null) {
+                        Image(
+                            bitmap = user.profilePicture,
+                            contentDescription = "Profile picture of ${user.firstName}",
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    } else {
+                        Image(
+                            painter = painterResource(id = R.drawable.settings_user),
+                            contentDescription = "Default profile picture",
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.fillMaxSize()
+                        )
+                    }
+                }
+
+                // User Name
+                Column {
+                    Text(
+                        text = "${user.firstName} ${user.lastName}",
+                        style = MaterialTheme.typography.bodyLarge.copy(
+                            fontWeight = FontWeight.Bold
+                        )
+                    )
+                }
+            }
+
+            // Unblock Button
+            Button(
+                onClick = { showConfirmDialog = true },
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Purple40
+                ),
+                modifier = Modifier.testTag("unblockButton_${user.uid}")
+            ) {
+                Text("Unblock")
+            }
+        }
+    }
+
+    if (showConfirmDialog) {
+        AlertDialog(
+            onDismissRequest = { showConfirmDialog = false },
+            title = {
+                Text(
+                    text = "Unblock User",
+                    style = MaterialTheme.typography.headlineSmall.copy(
+                        fontWeight = FontWeight.Bold
+                    )
+                )
+            },
+            text = {
+                Text(
+                    text = "Are you sure you want to unblock ${user.firstName} ${user.lastName}?",
+                    style = MaterialTheme.typography.bodyLarge
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        onUnblock(user)
+                        showConfirmDialog = false
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = Purple40)
+                ) {
+                    Text("Yes")
+                }
+            },
+            dismissButton = {
+                Button(
+                    onClick = { showConfirmDialog = false },
+                    colors = ButtonDefaults.buttonColors(containerColor = Color.Gray)
+                ) {
+                    Text("No")
+                }
+            }
+        )
+    }
+} 

--- a/app/src/main/java/com/swent/suddenbump/ui/overview/Settings.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/overview/Settings.kt
@@ -106,6 +106,13 @@ fun SettingsScreen(
                     modifier = Modifier.testTag("DiscussionsOption"))
               }
               item {
+                SettingsOption(
+                    label = "Blocked Users",
+                    backgroundColor = Color.White,
+                    onClick = { navigationActions.navigateTo("BlockedUsersScreen") },
+                    modifier = Modifier.testTag("BlockedUsersOption"))
+              }
+              item {
                 NotificationsSwitch(
                     notificationsEnabled = notificationsEnabled,
                     onCheckedChange = {

--- a/app/src/test/java/com/swent/suddenbump/model/user/UserRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/user/UserRepositoryFirestoreTest.kt
@@ -1631,8 +1631,7 @@ class UserRepositoryFirestoreTest {
     // Mock the update() method on user document to return a successful task
     `when`(userDocumentReference.update(anyString(), any())).thenReturn(Tasks.forResult(null))
     // Mock the update() method on friend document to return a failed task
-    `when`(friendDocumentReference.update(anyString(), any()))
-        .thenReturn(Tasks.forException(Exception("Update friend's sentFriendRequests failed")))
+    `when`(friendDocumentReference.update(anyString(), any())).thenReturn(Tasks.forException(Exception("Update friend's sentFriendRequests failed")))
 
     // Create the UserRepositoryFirestore instance
     val userRepository = UserRepositoryFirestore(mockFirestore, mock(Context::class.java))
@@ -2149,8 +2148,7 @@ class UserRepositoryFirestoreTest {
 
     `when`(mockUserDocumentReference.get()).thenReturn(Tasks.forResult(mockUserDocumentSnapshot))
     `when`(mockUserDocumentSnapshot.data).thenReturn(userData)
-    `when`(mockUserDocumentReference.update(anyString(), any()))
-        .thenReturn(Tasks.forException(exception))
+    `when`(mockUserDocumentReference.update(anyString(), any())).thenReturn(Tasks.forException(exception))
 
     // Act
     val latch = CountDownLatch(1)
@@ -2303,7 +2301,7 @@ class UserRepositoryFirestoreTest {
       `when`(mockTask.result)
           .thenReturn(mockUserDocumentSnapshot) // Return a mocked snapshot of the user document
       `when`(mockTask.addOnFailureListener(any()))
-          .thenReturn(mockTask) // Add failure listener (we won’t use it)
+          .thenReturn(mockTask) // Add failure listener (we won't use it)
       `when`(mockUserDocumentSnapshot.data)
           .thenReturn(mapOf("friendsList" to listOf(friendUid))) // Mocking the friends list data
 
@@ -2458,7 +2456,7 @@ class UserRepositoryFirestoreTest {
       `when`(mockTask.result)
           .thenReturn(mockUserDocumentSnapshot) // Return a mocked snapshot of the user document
       `when`(mockTask.addOnFailureListener(any()))
-          .thenReturn(mockTask) // Add failure listener (we won’t use it)
+          .thenReturn(mockTask) // Add failure listener (we won't use it)
       `when`(mockUserDocumentSnapshot.data)
           .thenReturn(mapOf("friendsList" to listOf(friendUid))) // Mocking the friends list data
 
@@ -3614,5 +3612,117 @@ class UserRepositoryFirestoreTest {
         onFailure = { fail("Should not fail when no data is available") })
 
     shadowOf(Looper.getMainLooper()).idle()
+  }
+
+  @Test
+  fun unblockUser_Success() {
+    // Mock document references
+    val currentUserRef = mock(DocumentReference::class.java)
+    val currentUserSnapshot = mock(DocumentSnapshot::class.java)
+    
+    // Mock initial blocked list
+    val blockedList = listOf("blocked_user_id")
+    `when`(currentUserSnapshot.get("blockedList")).thenReturn(blockedList)
+    
+    // Mock Firestore interactions
+    `when`(mockFirestore.collection("Users")).thenReturn(mockUserCollectionReference)
+    `when`(mockUserCollectionReference.document("current_user_id")).thenReturn(currentUserRef)
+    `when`(currentUserRef.get()).thenReturn(Tasks.forResult(currentUserSnapshot))
+    `when`(currentUserRef.update("blockedList", emptyList<String>())).thenReturn(Tasks.forResult(null))
+
+    var onSuccessCalled = false
+    var onFailureCalled = false
+
+    // Call unblockUser
+    userRepositoryFirestore.unblockUser(
+        "current_user_id",
+        "blocked_user_id",
+        onSuccess = { onSuccessCalled = true },
+        onFailure = { onFailureCalled = true }
+    )
+
+    // Ensure all asynchronous operations complete
+    shadowOf(Looper.getMainLooper()).idle()
+
+    // Verify success
+    assertTrue(onSuccessCalled)
+    assertFalse(onFailureCalled)
+    verify(currentUserRef).update("blockedList", emptyList<String>())
+  }
+
+  @Test
+  fun unblockUser_FailureOnGet() {
+    // Mock document references
+    val currentUserRef = mock(DocumentReference::class.java)
+    val exception = Exception("Failed to get document")
+
+    // Mock Firestore interactions with failure
+    `when`(mockFirestore.collection("Users")).thenReturn(mockUserCollectionReference)
+    `when`(mockUserCollectionReference.document("current_user_id")).thenReturn(currentUserRef)
+    `when`(currentUserRef.get()).thenReturn(Tasks.forException(exception))
+
+    var onSuccessCalled = false
+    var onFailureCalled = false
+    var failureException: Exception? = null
+
+    // Call unblockUser
+    userRepositoryFirestore.unblockUser(
+        "current_user_id",
+        "blocked_user_id",
+        onSuccess = { onSuccessCalled = true },
+        onFailure = { e -> 
+            onFailureCalled = true
+            failureException = e
+        }
+    )
+
+    // Ensure all asynchronous operations complete
+    shadowOf(Looper.getMainLooper()).idle()
+
+    // Verify failure
+    assertFalse(onSuccessCalled)
+    assertTrue(onFailureCalled)
+    assertEquals(exception, failureException)
+  }
+
+  @Test
+  fun unblockUser_FailureOnUpdate() {
+    // Mock document references
+    val currentUserRef = mock(DocumentReference::class.java)
+    val currentUserSnapshot = mock(DocumentSnapshot::class.java)
+    val exception = Exception("Failed to update document")
+    
+    // Mock initial blocked list
+    val blockedList = listOf("blocked_user_id")
+    `when`(currentUserSnapshot.get("blockedList")).thenReturn(blockedList)
+    
+    // Mock Firestore interactions with update failure
+    `when`(mockFirestore.collection("Users")).thenReturn(mockUserCollectionReference)
+    `when`(mockUserCollectionReference.document("current_user_id")).thenReturn(currentUserRef)
+    `when`(currentUserRef.get()).thenReturn(Tasks.forResult(currentUserSnapshot))
+    `when`(currentUserRef.update("blockedList", emptyList<String>())).thenReturn(Tasks.forException(exception))
+
+    var onSuccessCalled = false
+    var onFailureCalled = false
+    var failureException: Exception? = null
+
+    // Call unblockUser
+    userRepositoryFirestore.unblockUser(
+        "current_user_id",
+        "blocked_user_id",
+        onSuccess = { onSuccessCalled = true },
+        onFailure = { e -> 
+            onFailureCalled = true
+            failureException = e
+        }
+    )
+
+    // Ensure all asynchronous operations complete
+    shadowOf(Looper.getMainLooper()).idle()
+
+    // Verify failure
+    assertFalse(onSuccessCalled)
+    assertTrue(onFailureCalled)
+    assertEquals(exception, failureException)
   }
 }

--- a/app/src/test/java/com/swent/suddenbump/model/user/UserRepositoryFirestoreTest.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/user/UserRepositoryFirestoreTest.kt
@@ -1631,7 +1631,8 @@ class UserRepositoryFirestoreTest {
     // Mock the update() method on user document to return a successful task
     `when`(userDocumentReference.update(anyString(), any())).thenReturn(Tasks.forResult(null))
     // Mock the update() method on friend document to return a failed task
-    `when`(friendDocumentReference.update(anyString(), any())).thenReturn(Tasks.forException(Exception("Update friend's sentFriendRequests failed")))
+    `when`(friendDocumentReference.update(anyString(), any()))
+        .thenReturn(Tasks.forException(Exception("Update friend's sentFriendRequests failed")))
 
     // Create the UserRepositoryFirestore instance
     val userRepository = UserRepositoryFirestore(mockFirestore, mock(Context::class.java))
@@ -2148,7 +2149,8 @@ class UserRepositoryFirestoreTest {
 
     `when`(mockUserDocumentReference.get()).thenReturn(Tasks.forResult(mockUserDocumentSnapshot))
     `when`(mockUserDocumentSnapshot.data).thenReturn(userData)
-    `when`(mockUserDocumentReference.update(anyString(), any())).thenReturn(Tasks.forException(exception))
+    `when`(mockUserDocumentReference.update(anyString(), any()))
+        .thenReturn(Tasks.forException(exception))
 
     // Act
     val latch = CountDownLatch(1)
@@ -3619,16 +3621,17 @@ class UserRepositoryFirestoreTest {
     // Mock document references
     val currentUserRef = mock(DocumentReference::class.java)
     val currentUserSnapshot = mock(DocumentSnapshot::class.java)
-    
+
     // Mock initial blocked list
     val blockedList = listOf("blocked_user_id")
     `when`(currentUserSnapshot.get("blockedList")).thenReturn(blockedList)
-    
+
     // Mock Firestore interactions
     `when`(mockFirestore.collection("Users")).thenReturn(mockUserCollectionReference)
     `when`(mockUserCollectionReference.document("current_user_id")).thenReturn(currentUserRef)
     `when`(currentUserRef.get()).thenReturn(Tasks.forResult(currentUserSnapshot))
-    `when`(currentUserRef.update("blockedList", emptyList<String>())).thenReturn(Tasks.forResult(null))
+    `when`(currentUserRef.update("blockedList", emptyList<String>()))
+        .thenReturn(Tasks.forResult(null))
 
     var onSuccessCalled = false
     var onFailureCalled = false
@@ -3638,8 +3641,7 @@ class UserRepositoryFirestoreTest {
         "current_user_id",
         "blocked_user_id",
         onSuccess = { onSuccessCalled = true },
-        onFailure = { onFailureCalled = true }
-    )
+        onFailure = { onFailureCalled = true })
 
     // Ensure all asynchronous operations complete
     shadowOf(Looper.getMainLooper()).idle()
@@ -3670,11 +3672,10 @@ class UserRepositoryFirestoreTest {
         "current_user_id",
         "blocked_user_id",
         onSuccess = { onSuccessCalled = true },
-        onFailure = { e -> 
-            onFailureCalled = true
-            failureException = e
-        }
-    )
+        onFailure = { e ->
+          onFailureCalled = true
+          failureException = e
+        })
 
     // Ensure all asynchronous operations complete
     shadowOf(Looper.getMainLooper()).idle()
@@ -3691,16 +3692,17 @@ class UserRepositoryFirestoreTest {
     val currentUserRef = mock(DocumentReference::class.java)
     val currentUserSnapshot = mock(DocumentSnapshot::class.java)
     val exception = Exception("Failed to update document")
-    
+
     // Mock initial blocked list
     val blockedList = listOf("blocked_user_id")
     `when`(currentUserSnapshot.get("blockedList")).thenReturn(blockedList)
-    
+
     // Mock Firestore interactions with update failure
     `when`(mockFirestore.collection("Users")).thenReturn(mockUserCollectionReference)
     `when`(mockUserCollectionReference.document("current_user_id")).thenReturn(currentUserRef)
     `when`(currentUserRef.get()).thenReturn(Tasks.forResult(currentUserSnapshot))
-    `when`(currentUserRef.update("blockedList", emptyList<String>())).thenReturn(Tasks.forException(exception))
+    `when`(currentUserRef.update("blockedList", emptyList<String>()))
+        .thenReturn(Tasks.forException(exception))
 
     var onSuccessCalled = false
     var onFailureCalled = false
@@ -3711,11 +3713,10 @@ class UserRepositoryFirestoreTest {
         "current_user_id",
         "blocked_user_id",
         onSuccess = { onSuccessCalled = true },
-        onFailure = { e -> 
-            onFailureCalled = true
-            failureException = e
-        }
-    )
+        onFailure = { e ->
+          onFailureCalled = true
+          failureException = e
+        })
 
     // Ensure all asynchronous operations complete
     shadowOf(Looper.getMainLooper()).idle()

--- a/app/src/test/java/com/swent/suddenbump/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/user/UserViewModelTest.kt
@@ -786,61 +786,61 @@ class UserViewModelTest {
   @Test
   fun testUnblockUser_Success() = runTest {
     // Arrange
-    val currentUser = User(
-        "current_id",
-        "Current",
-        "User",
-        "+41789123450",
-        null,
-        "current.user@example.com",
-        MutableStateFlow(Location("mock_provider"))
-    )
-    val blockedUser = User(
-        "blocked_id",
-        "Blocked",
-        "User",
-        "+41789123456",
-        null,
-        "blocked.user@example.com",
-        MutableStateFlow(Location("mock_provider"))
-    )
+    val currentUser =
+        User(
+            "current_id",
+            "Current",
+            "User",
+            "+41789123450",
+            null,
+            "current.user@example.com",
+            MutableStateFlow(Location("mock_provider")))
+    val blockedUser =
+        User(
+            "blocked_id",
+            "Blocked",
+            "User",
+            "+41789123456",
+            null,
+            "blocked.user@example.com",
+            MutableStateFlow(Location("mock_provider")))
 
     // Set current user
     userViewModel.setUser(currentUser, {}, {})
 
     // Mock setBlockedFriends behavior
     doAnswer { invocation ->
-        val uid = invocation.getArgument<String>(0)
-        val blockedList = invocation.getArgument<List<User>>(1)
-        val onSuccess = invocation.getArgument<() -> Unit>(2)
-        onSuccess()
-        null
-    }.whenever(userRepository).setBlockedFriends(any(), any(), any(), any())
+          val uid = invocation.getArgument<String>(0)
+          val blockedList = invocation.getArgument<List<User>>(1)
+          val onSuccess = invocation.getArgument<() -> Unit>(2)
+          onSuccess()
+          null
+        }
+        .whenever(userRepository)
+        .setBlockedFriends(any(), any(), any(), any())
 
     // Add user to blocked list initially
     userViewModel.setBlockedFriends(
-        blockedFriendsList = listOf(blockedUser),
-        onSuccess = {},
-        onFailure = {}
-    )
+        blockedFriendsList = listOf(blockedUser), onSuccess = {}, onFailure = {})
 
     var onSuccessCalled = false
     var onFailureCalled = false
 
     // Mock unblockUser behavior
     doAnswer { invocation ->
-        val onSuccess = invocation.getArgument<() -> Unit>(2)
-        onSuccess()
-        null
-    }.whenever(userRepository).unblockUser(any(), any(), any(), any())
+          val onSuccess = invocation.getArgument<() -> Unit>(2)
+          onSuccess()
+          null
+        }
+        .whenever(userRepository)
+        .unblockUser(any(), any(), any(), any())
 
     // Act
     userViewModel.unblockUser(
         blockedUser = blockedUser,
         onSuccess = { onSuccessCalled = true },
-        onFailure = { onFailureCalled = true }
-    )
-    
+        onFailure = { onFailureCalled = true })
+
     advanceUntilIdle()
 
     // Assert
@@ -853,24 +853,24 @@ class UserViewModelTest {
   @Test
   fun testUnblockUser_Failure() = runTest {
     // Arrange
-    val currentUser = User(
-        "current_id",
-        "Current",
-        "User",
-        "+41789123450",
-        null,
-        "current.user@example.com",
-        MutableStateFlow(Location("mock_provider"))
-    )
-    val blockedUser = User(
-        "blocked_id",
-        "Blocked",
-        "User",
-        "+41789123456",
-        null,
-        "blocked.user@example.com",
-        MutableStateFlow(Location("mock_provider"))
-    )
+    val currentUser =
+        User(
+            "current_id",
+            "Current",
+            "User",
+            "+41789123450",
+            null,
+            "current.user@example.com",
+            MutableStateFlow(Location("mock_provider")))
+    val blockedUser =
+        User(
+            "blocked_id",
+            "Blocked",
+            "User",
+            "+41789123456",
+            null,
+            "blocked.user@example.com",
+            MutableStateFlow(Location("mock_provider")))
     val error = Exception("Failed to unblock user")
 
     // Set current user
@@ -878,19 +878,18 @@ class UserViewModelTest {
 
     // Mock setBlockedFriends behavior
     doAnswer { invocation ->
-        val uid = invocation.getArgument<String>(0)
-        val blockedList = invocation.getArgument<List<User>>(1)
-        val onSuccess = invocation.getArgument<() -> Unit>(2)
-        onSuccess()
-        null
-    }.whenever(userRepository).setBlockedFriends(any(), any(), any(), any())
+          val uid = invocation.getArgument<String>(0)
+          val blockedList = invocation.getArgument<List<User>>(1)
+          val onSuccess = invocation.getArgument<() -> Unit>(2)
+          onSuccess()
+          null
+        }
+        .whenever(userRepository)
+        .setBlockedFriends(any(), any(), any(), any())
 
     // Add user to blocked list initially
     userViewModel.setBlockedFriends(
-        blockedFriendsList = listOf(blockedUser),
-        onSuccess = {},
-        onFailure = {}
-    )
+        blockedFriendsList = listOf(blockedUser), onSuccess = {}, onFailure = {})
 
     var onSuccessCalled = false
     var onFailureCalled = false
@@ -898,21 +897,22 @@ class UserViewModelTest {
 
     // Mock unblockUser behavior to fail
     doAnswer { invocation ->
-        val onFailure = invocation.getArgument<(Exception) -> Unit>(3)
-        onFailure(error)
-        null
-    }.whenever(userRepository).unblockUser(any(), any(), any(), any())
+          val onFailure = invocation.getArgument<(Exception) -> Unit>(3)
+          onFailure(error)
+          null
+        }
+        .whenever(userRepository)
+        .unblockUser(any(), any(), any(), any())
 
     // Act
     userViewModel.unblockUser(
         blockedUser = blockedUser,
         onSuccess = { onSuccessCalled = true },
-        onFailure = { e -> 
-            onFailureCalled = true
-            failureException = e
-        }
-    )
-    
+        onFailure = { e ->
+          onFailureCalled = true
+          failureException = e
+        })
+
     advanceUntilIdle()
 
     // Assert


### PR DESCRIPTION
### Add Blocked Users Screen with Unblock Functionality

**Description**
This PR adds a new screen to manage blocked users and implements the unblock functionality.

**Changes**
- Added new BlockedUsersScreen composable with list of blocked users
- Implemented unblock functionality with confirmation dialog
- Added unblockUser method to UserRepository interface
- Implemented unblockUser in UserRepositoryFirestore
- Added unblockUser to UserViewModel with state management
- Added comprehensive tests for BlockedUsersScreen
- Added unit tests for unblockUser in UserViewModel and UserRepositoryFirestore
- Updated navigation graph to include BlockedUsersScreen
- Added unique test tags for unblock buttons to improve testability
- Implemented confirmation dialog for unblock action to prevent accidental unblocks
- Added proper error handling for unblock operations