### PR TITLE
Use notifications to allow/refuse location

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <receiver android:name=".ActionReceiver" />
         <activity
             android:name="com.yalantis.ucrop.UCropActivity"
             android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>

--- a/app/src/main/java/com/swent/suddenbump/ActionReceiver.kt
+++ b/app/src/main/java/com/swent/suddenbump/ActionReceiver.kt
@@ -1,0 +1,48 @@
+package com.swent.suddenbump
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.app.NotificationManagerCompat
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import com.swent.suddenbump.model.user.UserRepositoryFirestore
+
+class ActionReceiver : BroadcastReceiver() {
+  override fun onReceive(context: Context, intent: Intent) {
+    val extras = intent.extras
+    val userUID = extras?.getString("userUID")
+    val friendUID = extras?.getString("FriendUID")
+    val notifID = extras?.getInt("notificationId")
+    val notificationManager = NotificationManagerCompat.from(context)
+    val repository = UserRepositoryFirestore(Firebase.firestore, context)
+    when (intent.action) {
+      "ACTION_ACCEPT" -> {
+        Log.d("IntentSB", "Accept button clicked")
+        // Handle the accept action
+        Log.d("IntentSB", "userUID: $userUID, friendUID: $friendUID")
+        notificationManager.cancel(notifID!!)
+        repository.shareLocationWithFriend(
+            userUID!!,
+            friendUID!!,
+            onSuccess = { Log.d("IntentSB", "Successfully shared location with friend") },
+            onFailure = { Log.d("IntentSB", "Failed to share location with friend") })
+      }
+      "ACTION_REFUSE" -> {
+        Log.d("IntentSB", "Refuse button clicked")
+        Log.d("IntentSB", "userUID: $userUID, friendUID: $friendUID")
+        // Handle the refuse action
+        notificationManager.cancel(notifID!!)
+        repository.stopSharingLocationWithFriend(
+            userUID!!,
+            friendUID!!,
+            onSuccess = { Log.d("IntentSB", "Successfully removed friend") },
+            onFailure = { Log.d("IntentSB", "Failed to remove friend") })
+      }
+      else -> {
+        Log.d("IntentSB", "Unknown action")
+      }
+    }
+  }
+}

--- a/app/src/main/java/com/swent/suddenbump/model/user/UserRepository.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/user/UserRepository.kt
@@ -160,6 +160,10 @@ interface UserRepository {
 
   fun getSavedUid(): String
 
+  fun saveNotifiedFriends(friends: List<String>)
+
+  fun getSavedAlreadyNotifiedFriends(): List<String>
+
   fun isUserLoggedIn(): Boolean
 
   fun logoutUser()

--- a/app/src/main/java/com/swent/suddenbump/model/user/UserRepositoryFirestore.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/user/UserRepositoryFirestore.kt
@@ -17,6 +17,8 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.StorageReference
 import com.google.firebase.storage.ktx.storage
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
 import com.swent.suddenbump.MainActivity
 import com.swent.suddenbump.model.image.ImageRepository
 import com.swent.suddenbump.model.image.ImageRepositoryFirebaseStorage
@@ -1069,6 +1071,27 @@ class UserRepositoryFirestore(private val db: FirebaseFirestore, private val con
    */
   override fun getSavedUid(): String {
     return sharedPreferences.getString("userId", null) ?: ""
+  }
+
+  override fun saveNotifiedFriends(friendsUID: List<String>) {
+    val gson = Gson()
+    val jsonString = gson.toJson(friendsUID) // Convert list to JSON string
+    sharedPreferences.edit().putString("notified_friends", jsonString).apply()
+  }
+
+  /**
+   * Retrieves the saved friends ID from shared preferences.
+   *
+   * @return The saved friends ID as a String, or an empty string if no user is logged in.
+   */
+  override fun getSavedAlreadyNotifiedFriends(): List<String> {
+    val gson = Gson()
+    val jsonString = sharedPreferences.getString("notified_friends", null)
+    return if (jsonString != null) {
+      gson.fromJson(jsonString, object : TypeToken<List<String>>() {}.type)
+    } else {
+      emptyList() // Return an empty list if no data is found
+    }
   }
 
   /**

--- a/app/src/main/java/com/swent/suddenbump/ui/map/Map.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/map/Map.kt
@@ -11,6 +11,7 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.location.Location
+import android.os.Bundle
 import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -34,6 +35,7 @@ import com.google.maps.android.compose.Marker
 import com.google.maps.android.compose.MarkerState
 import com.google.maps.android.compose.rememberCameraPositionState
 import com.google.maps.android.compose.rememberMarkerState
+import com.swent.suddenbump.ActionReceiver
 import com.swent.suddenbump.MainActivity
 import com.swent.suddenbump.model.user.User
 import com.swent.suddenbump.model.user.UserViewModel
@@ -151,35 +153,71 @@ fun fetchLocationToServer(location: Location, userViewModel: UserViewModel) {
       onFailure = { Log.d("FireStoreLocation", "Failure to reach Firestore") })
 }
 
-fun showFriendNearbyNotification(context: Context) {
+fun showFriendNearbyNotification(context: Context, userUID: String, friend: User) {
   val channelId = "friend_nearby_channel"
   val channelName = "Friend Nearby Notifications"
-  val notificationId = 1
+  val notificationId = friend.uid.hashCode()
 
   val notificationChannel =
       NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_HIGH)
   val notificationManager = context.getSystemService(NotificationManager::class.java)
   notificationManager?.createNotificationChannel(notificationChannel)
 
-  // Modify the intent to navigate to Screen.OVERVIEW
   val intent =
       Intent(context, MainActivity::class.java).apply {
-        putExtra("destination", "Screen.OVERVIEW")
-        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT
       }
 
   val pendingIntent: PendingIntent =
       PendingIntent.getActivity(
           context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
 
+  val bundle =
+      Bundle().apply {
+        putString("userUID", userUID) // Add key-value pairs to the bundle
+        putString("FriendUID", friend.uid)
+        putInt("notificationId", notificationId)
+      }
+
+  // Create intents for Accept and Refuse actions
+  val acceptIntent =
+      Intent(context, ActionReceiver::class.java).apply {
+        action = "ACTION_ACCEPT"
+        putExtras(bundle)
+      }
+
+  val refuseIntent =
+      Intent(context, ActionReceiver::class.java).apply {
+        action = "ACTION_REFUSE"
+        putExtras(bundle)
+      }
+
+  val acceptPendingIntent: PendingIntent =
+      PendingIntent.getBroadcast(
+          context,
+          1,
+          acceptIntent,
+          PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+
+  val refusePendingIntent: PendingIntent =
+      PendingIntent.getBroadcast(
+          context,
+          2,
+          refuseIntent,
+          PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+
+  // Build the notification with actions
   val notificationBuilder =
       NotificationCompat.Builder(context, channelId)
           .setSmallIcon(android.R.drawable.ic_dialog_info)
           .setContentTitle("Friend Nearby")
-          .setContentText("A friend is within your radius!")
+          .setContentText(
+              "${friend.firstName} ${friend.lastName} is within your radius! \n Would you like to share your location with them?")
           .setPriority(NotificationCompat.PRIORITY_HIGH)
           .setContentIntent(pendingIntent)
           .setAutoCancel(true)
+          .addAction(android.R.drawable.ic_menu_compass, "Accept", acceptPendingIntent)
+          .addAction(android.R.drawable.ic_menu_close_clear_cancel, "Refuse", refusePendingIntent)
 
   try {
     with(NotificationManagerCompat.from(context)) {

--- a/app/src/test/java/com/swent/suddenbump/ActionReceiverTest.kt
+++ b/app/src/test/java/com/swent/suddenbump/ActionReceiverTest.kt
@@ -1,0 +1,96 @@
+package com.swent.suddenbump
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationManagerCompat
+import com.swent.suddenbump.model.user.UserRepositoryFirestore
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.*
+import org.mockito.MockitoAnnotations
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(RobolectricTestRunner::class)
+class ActionReceiverTest {
+
+  private lateinit var context: Context
+  private lateinit var intent: Intent
+  private lateinit var mockNotificationManager: NotificationManagerCompat
+  private lateinit var mockRepository: UserRepositoryFirestore
+  private lateinit var actionReceiver: ActionReceiver
+
+  @Before
+  fun setUp() {
+    MockitoAnnotations.openMocks(this)
+
+    // Initialize context using Robolectric
+    context = RuntimeEnvironment.getApplication()
+
+    intent = Intent()
+
+    // Mock NotificationManagerCompat
+    mockNotificationManager = mock(NotificationManagerCompat::class.java)
+
+    // Mock UserRepositoryFirestore
+    mockRepository = mock(UserRepositoryFirestore::class.java)
+
+    // Inject mocked dependencies into ActionReceiver
+    actionReceiver =
+        ActionReceiver(
+            notificationManagerFactory = { mockNotificationManager },
+            userRepositoryFactory = { mockRepository })
+  }
+
+  @Test
+  fun onReceiveShouldHandleActionAccept() {
+    // Arrange
+    intent.action = "ACTION_ACCEPT"
+    intent.putExtra("userUID", "user123")
+    intent.putExtra("FriendUID", "friend456")
+    intent.putExtra("notificationId", 1)
+
+    // Act
+    actionReceiver.onReceive(context, intent)
+
+    // Assert
+    verify(mockNotificationManager).cancel(eq(1))
+    verify(mockRepository).shareLocationWithFriend(eq("user123"), eq("friend456"), any(), any())
+  }
+
+  @Test
+  fun onReceiveShouldHandleActionRefuse() {
+    // Arrange
+    intent.action = "ACTION_REFUSE"
+    intent.putExtra("userUID", "user123")
+    intent.putExtra("FriendUID", "friend456")
+    intent.putExtra("notificationId", 2)
+
+    // Act
+    actionReceiver.onReceive(context, intent)
+
+    // Assert
+    verify(mockNotificationManager).cancel(eq(2))
+    verify(mockRepository)
+        .stopSharingLocationWithFriend(eq("user123"), eq("friend456"), any(), any())
+  }
+
+  @Test
+  fun onReceiveShouldHandleUnknownAction() {
+    // Arrange
+    intent.action = "UNKNOWN_ACTION"
+    intent.putExtra("userUID", "user123")
+    intent.putExtra("FriendUID", "friend456")
+    intent.putExtra("notificationId", 3)
+
+    // Act
+    actionReceiver.onReceive(context, intent)
+
+    // Assert
+    verifyNoInteractions(mockNotificationManager)
+    verifyNoInteractions(mockRepository)
+  }
+}


### PR DESCRIPTION
## 🔄 Changes Overview

This PR introduces notifications for location sharing requests, local storage of friends triggering notifications, and tests for related functionality.

---

## 💡 New Features

### Notifications
- **Location Sharing Requests**: Launched a notification for each user, allowing them to accept or refuse location sharing.

### Local Storage
- **Friend Notifications**: Stored the list of friends that triggered notifications locally for better tracking and user experience.

---

## 🧪 Testing

- **`saveNotifiedFriends` and `getSavedAlreadyNotifiedFriends`**: Added tests to ensure the proper saving and retrieval of friends that have already triggered notifications.
- **`ActionReceiver`**: Tested the receiver logic to validate actions triggered by notifications.

---

## 🛠️ Technical Implementation

- Integrated notification handling for location sharing.
- Implemented local storage with json for friends who already notified .
