### PR TITLE
update ui of overview screen to include location sharing toggle

### DIFF
--- a/app/src/androidTest/java/com/swent/suddenbump/ui/overview/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/overview/OverviewScreenTest.kt
@@ -22,6 +22,7 @@ class OverviewScreenTest {
 
   private lateinit var navigationActions: NavigationActions
   private lateinit var userViewModel: UserViewModel
+  private lateinit var locationSharedWithState: MutableStateFlow<List<User>>
 
   private val location1 =
       Location("mock_provider").apply {
@@ -74,6 +75,9 @@ class OverviewScreenTest {
     coEvery { userViewModel.getCityAndCountry(any()) } returns
         "San Francisco, USA" andThen
         "New York, USA"
+
+    locationSharedWithState = MutableStateFlow<List<User>>(emptyList())
+    every { userViewModel.locationSharedWith } returns locationSharedWithState
   }
 
   @Test
@@ -162,9 +166,6 @@ class OverviewScreenTest {
 
   @Test
   fun testIconToggleButton_ShowsCorrectIconAndTogglesState() {
-    // Initial mock state for location sharing
-    val locationSharedWithState = MutableStateFlow(emptyList<User>())
-    every { userViewModel.locationSharedWith } returns locationSharedWithState
 
     val currentUser = user1
     val friend = user2

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/overview/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/overview/OverviewScreenTest.kt
@@ -159,4 +159,59 @@ class OverviewScreenTest {
         .onNodeWithTag("profileImageNotNull_${user2.uid}", useUnmergedTree = true)
         .assertIsDisplayed()
   }
+
+  @Test
+  fun testIconToggleButton_ShowsCorrectIconAndTogglesState() {
+    // Initial mock state for location sharing
+    val locationSharedWithState = MutableStateFlow(emptyList<User>())
+    every { userViewModel.locationSharedWith } returns locationSharedWithState
+
+    val currentUser = user1
+    val friend = user2
+
+    composeTestRule.setContent { OverviewScreen(navigationActions, userViewModel) }
+
+    // Verify initial state (location sharing is off)
+    composeTestRule
+        .onNodeWithTag("locationIcon_${friend.uid}", useUnmergedTree = true)
+        .assertExists()
+        .assertContentDescriptionEquals("Share location")
+        .assertIsDisplayed()
+
+    // Simulate clicking the icon to enable location sharing
+    composeTestRule
+        .onNodeWithTag("locationIcon_${friend.uid}", useUnmergedTree = true)
+        .performClick()
+
+    // Verify that the ViewModel method to share location is called
+    verify { userViewModel.shareLocationWithFriend(currentUser.uid, friend, any(), any()) }
+
+    // Simulate state change after sharing location
+    locationSharedWithState.value = listOf(friend)
+
+    // Verify state after enabling location sharing
+    composeTestRule
+        .onNodeWithTag("locationIcon_${friend.uid}", useUnmergedTree = true)
+        .assertExists()
+        .assertContentDescriptionEquals("Stop sharing location")
+        .assertIsDisplayed()
+
+    // Simulate clicking the icon to disable location sharing
+    composeTestRule
+        .onNodeWithTag("locationIcon_${friend.uid}", useUnmergedTree = true)
+        .performClick()
+
+    // Verify that the ViewModel method to stop sharing location is called
+    verify { userViewModel.stopSharingLocationWithFriend(currentUser.uid, friend, any(), any()) }
+
+    // Simulate state change after stopping location sharing
+    locationSharedWithState.value = emptyList()
+
+    // Verify state after disabling location sharing
+    composeTestRule
+        .onNodeWithTag("locationIcon_${friend.uid}", useUnmergedTree = true)
+        .assertExists()
+        .assertContentDescriptionEquals("Share location")
+        .assertIsDisplayed()
+  }
 }

--- a/app/src/main/java/com/swent/suddenbump/model/user/UserRepositoryFirestore.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/user/UserRepositoryFirestore.kt
@@ -1220,8 +1220,6 @@ class UserRepositoryFirestore(private val db: FirebaseFirestore, private val con
         .get()
         .addOnFailureListener { e -> onFailure(e) }
         .addOnSuccessListener { result ->
-          println("Document data: ${result.data}")
-          println("locationSharedWith: ${result.data?.get("locationSharedWith")}")
           if (result.data?.get("locationSharedBy") == null) {
             emptyList<User>()
           } else {
@@ -1249,8 +1247,6 @@ class UserRepositoryFirestore(private val db: FirebaseFirestore, private val con
         .get()
         .addOnFailureListener { e -> onFailure(e) }
         .addOnSuccessListener { result ->
-          println("Document data: ${result.data}")
-          println("locationSharedWith: ${result.data?.get("locationSharedWith")}")
           if (result.data?.get("locationSharedWith") == null) {
             emptyList<User>()
           } else {

--- a/app/src/main/java/com/swent/suddenbump/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/user/UserViewModel.kt
@@ -179,7 +179,6 @@ open class UserViewModel(
           _user.value = user
           saveUserLoginStatus(_user.value.uid)
           scheduleLocationUpdateWorker(getApplicationContext(), _user.value.uid)
-          Log.d(logTag, "User set 1: ${_user.value}")
           repository.getUserFriends(
               uid = _user.value.uid,
               onSuccess = { friendsList ->
@@ -223,7 +222,6 @@ open class UserViewModel(
         uid,
         onSuccess = {
           _user.value = it
-          Log.d(logTag, "User set 2: ${_user.value}")
           repository.getUserFriends(
               uid = _user.value.uid,
               onSuccess = { friendsList ->

--- a/app/src/main/java/com/swent/suddenbump/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/user/UserViewModel.kt
@@ -211,6 +211,7 @@ open class UserViewModel(
         uid,
         onSuccess = {
           _user.value = it
+          Log.d(logTag, "User set 2: ${_user.value}")
           repository.getUserFriends(
               uid = _user.value.uid,
               onSuccess = { friendsList ->
@@ -465,21 +466,27 @@ open class UserViewModel(
   }
 
   fun loadFriends() {
-    try {
-      repository.getUserFriends(
-          uid = _user.value.uid,
-          onSuccess = { friends ->
-            // Update the state with the locations of friends
-            _userFriends.value = friends
-            Log.d("FriendsMarkers", "On success load Friends ${_userFriends.value}")
-          },
-          onFailure = { error ->
-            // Handle the error, e.g., log or show error message
-            Log.e("UserViewModel", "Failed to load friends' : ${error.message}")
-          })
-    } catch (e: Exception) {
-      Log.e("UserViewModel", e.toString())
-    }
+    repository.getUserFriends(
+        uid = _user.value.uid,
+        onSuccess = { friends ->
+          // Update the state with the locations of friends
+          _userFriends.value = friends
+          Log.d("UserViewModel", "On success load Friends ${_userFriends.value}")
+        },
+        onFailure = { error ->
+          // Handle the error, e.g., log or show error message
+          Log.e("UserViewModel", "Failed to load friends' : ${error.message}")
+        })
+    Log.d("UserViewModel", "Loading sharedLocationWith...")
+    repository.getSharedWithFriends(
+        uid = _user.value.uid,
+        onSuccess = { list ->
+          _locationSharedWith.value = list
+          Log.d("UserViewModel", "Successfully loaded sharedLocationWith: $list")
+        },
+        onFailure = { error ->
+          Log.e("UserViewModel", "Failed to load sharedLocationWith : ${error.message}")
+        })
   }
 
   fun getSelectedContact(): StateFlow<User> {
@@ -700,7 +707,11 @@ open class UserViewModel(
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    _locationSharedWith.value = _locationSharedWith.value.minus(friend)
+    _locationSharedWith.value.forEach {
+      if (it.uid == friend.uid) {
+        _locationSharedWith.value = _locationSharedWith.value.minus(it)
+      }
+    }
     repository.stopSharingLocationWithFriend(uid, friend.uid, onSuccess, onFailure)
   }
 

--- a/app/src/main/java/com/swent/suddenbump/ui/map/Map.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/map/Map.kt
@@ -98,8 +98,10 @@ fun FriendsMarkers(userViewModel: UserViewModel) {
 
   LaunchedEffect(userViewModel) {
     launch {
-      userViewModel.loadFriends()
-      friends.value = userViewModel.getUserFriends().value
+      userViewModel.getLocationSharedBy(
+          userViewModel.getCurrentUser().value.uid,
+          onSuccess = { friends.value = it },
+          onFailure = { Log.d("FriendsMarkers", "Failed to get friends") })
       // Log the friendsLocations
       Log.d("FriendsMarkers", "Friends Locations: $friends")
     }

--- a/app/src/main/java/com/swent/suddenbump/ui/overview/FriendsList.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/overview/FriendsList.kt
@@ -154,11 +154,3 @@ fun FriendsListScreen(navigationActions: NavigationActions, userViewModel: UserV
             }
       })
 }
-
-// @Preview(showBackground = true)
-// @Composable
-// fun PreviewAddContactScreen() {
-//  val navController = rememberNavController()
-//  val navigationActions = NavigationActions(navController)
-//  FriendsListScreen(navigationActions,)
-// }

--- a/app/src/main/java/com/swent/suddenbump/ui/overview/Overview.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/overview/Overview.kt
@@ -63,11 +63,7 @@ fun OverviewScreen(navigationActions: NavigationActions, userViewModel: UserView
   val groupedFriends by userViewModel.groupedFriends.collectAsState()
 
   // Charge les emplacements des amis lorsque l'écran est composé
-  LaunchedEffect(Unit) {
-    Log.d("OverviewScreen", "currentUser: $currentUser")
-    Log.d("OverviewScreen", "groupedFriends: $groupedFriends")
-    userViewModel.loadFriends()
-  }
+  LaunchedEffect(Unit) { userViewModel.loadFriends() }
 
   Scaffold(
       topBar = {
@@ -123,7 +119,6 @@ fun OverviewScreen(navigationActions: NavigationActions, userViewModel: UserView
                     .padding(horizontal = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally) {
               if (groupedFriends?.isNotEmpty() == true) {
-                Log.d("OverviewScreen", "groupedFriends 2: $groupedFriends")
                 groupedFriends!!
                     .entries
                     .sortedBy { it.key.ordinal }
@@ -187,8 +182,6 @@ fun UserRow(user: User, navigationActions: NavigationActions, userViewModel: Use
   locationSharedWith.forEach { friend ->
     isLocationShared = isLocationShared || friend.uid == user.uid
   }
-  Log.d("UserRow", "isLocationShared: $isLocationShared")
-  Log.d("UserRow", "locationSharedWith: $locationSharedWith")
 
   LaunchedEffect(user.uid) {
     coroutineScope.launch {
@@ -249,7 +242,7 @@ fun UserRow(user: User, navigationActions: NavigationActions, userViewModel: Use
                     friend = user,
                     onSuccess = { isLocationShared = true },
                     onFailure = { exception ->
-                      println("Failed to share location: ${exception.message}")
+                      Log.e("Overview", "Failed to share location: ${exception.message}")
                     })
               } else {
                 userViewModel.stopSharingLocationWithFriend(
@@ -257,7 +250,7 @@ fun UserRow(user: User, navigationActions: NavigationActions, userViewModel: Use
                     friend = user,
                     onSuccess = { isLocationShared = false },
                     onFailure = { exception ->
-                      println("Failed to stop sharing location: ${exception.message}")
+                      Log.e("Overview", "Failed to stop sharing location: ${exception.message}")
                     })
               }
             }) {

--- a/app/src/main/res/drawable/baseline_location_off_24.xml
+++ b/app/src/main/res/drawable/baseline_location_off_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,6.5c1.38,0 2.5,1.12 2.5,2.5 0,0.74 -0.33,1.39 -0.83,1.85l3.63,3.63c0.98,-1.86 1.7,-3.8 1.7,-5.48 0,-3.87 -3.13,-7 -7,-7 -1.98,0 -3.76,0.83 -5.04,2.15l3.19,3.19c0.46,-0.52 1.11,-0.84 1.85,-0.84zM16.37,16.1l-4.63,-4.63 -0.11,-0.11L3.27,3 2,4.27l3.18,3.18C5.07,7.95 5,8.47 5,9c0,5.25 7,13 7,13s1.67,-1.85 3.38,-4.35L18.73,21 20,19.73l-3.63,-3.63z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/baseline_location_on_24.xml
+++ b/app/src/main/res/drawable/baseline_location_on_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z"/>
+    
+</vector>


### PR DESCRIPTION
This PR includes UI changes that go with the backend modifications made in PR #253.

We are now able to switch on and off the location sharing with a friend through a toggle on the overview screen. This toggle has a direct impact on if this friend can see us on the map or not.

We now see only the friends that shared their location with us on the map.

I also added some simple UI tests to accompany this new modification.