### PR TITLE
319 show google account picker after sign out

### DIFF
--- a/app/src/main/java/com/swent/suddenbump/ui/overview/AccountScreen.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/overview/AccountScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.google.firebase.auth.FirebaseAuth
 import com.swent.suddenbump.model.user.UserViewModel
 import com.swent.suddenbump.ui.navigation.NavigationActions
 import com.swent.suddenbump.ui.navigation.Route
@@ -81,6 +82,7 @@ fun AccountScreen(navigationActions: NavigationActions, userViewModel: UserViewM
                     backgroundColor = Pink40,
                     onClick = {
                       userViewModel.logout()
+                      FirebaseAuth.getInstance().signOut()
                       navigationActions.navigateTo(Route.AUTH)
                       Toast.makeText(context, "Logged out successfully !", Toast.LENGTH_LONG).show()
                     },

--- a/app/src/main/java/com/swent/suddenbump/ui/overview/AccountScreen.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/overview/AccountScreen.kt
@@ -15,7 +15,10 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.google.android.gms.auth.api.signin.GoogleSignIn
+import com.google.android.gms.auth.api.signin.GoogleSignInOptions
 import com.google.firebase.auth.FirebaseAuth
+import com.swent.suddenbump.R
 import com.swent.suddenbump.model.user.UserViewModel
 import com.swent.suddenbump.ui.navigation.NavigationActions
 import com.swent.suddenbump.ui.navigation.Route
@@ -83,8 +86,29 @@ fun AccountScreen(navigationActions: NavigationActions, userViewModel: UserViewM
                     onClick = {
                       userViewModel.logout()
                       FirebaseAuth.getInstance().signOut()
+                      val gso =
+                          GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN)
+                              .requestIdToken(context.getString(R.string.default_web_client_id))
+                              .requestEmail()
+                              .build()
+
+                      val googleSignInClient = GoogleSignIn.getClient(context, gso)
+
+                      // Sign out from Google account
+                      googleSignInClient.signOut().addOnCompleteListener { task ->
+                        if (task.isSuccessful) {
+                          Toast.makeText(context, "Logged out successfully!", Toast.LENGTH_LONG)
+                              .show()
+                        }
+                      }
+
+                      // Optional: Revoke access (forces account picker next time)
+                      googleSignInClient.revokeAccess().addOnCompleteListener { task ->
+                        if (task.isSuccessful) {
+                          Toast.makeText(context, "Failed to log out!", Toast.LENGTH_LONG).show()
+                        }
+                      }
                       navigationActions.navigateTo(Route.AUTH)
-                      Toast.makeText(context, "Logged out successfully !", Toast.LENGTH_LONG).show()
                     },
                     testTag = "logoutSection")
               }


### PR DESCRIPTION
When logging out, we are now able to select another Google Account when logging back in, without having to clear the app's data from the android settings.

I used the GoogleSignInOptions and GoogleSignInClient and used their signOut() and revokeAccess() functions.