### PR TITLE
Fix the location (0,0) problem

### DIFF
--- a/app/src/androidTest/java/com/swent/suddenbump/ui/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/MainActivityTest.kt
@@ -75,7 +75,7 @@ class MainActivityTest {
             phoneNumber = "1234567890",
             profilePicture = null,
             emailAddress = "test.user@example.com",
-            lastKnownLocation = MutableStateFlow(userLocation))
+            lastKnownLocation = userLocation)
 
     val friend =
         User(
@@ -85,7 +85,7 @@ class MainActivityTest {
             phoneNumber = "0987654321",
             profilePicture = null,
             emailAddress = "friend.user@example.com",
-            lastKnownLocation = MutableStateFlow(friendLocation))
+            lastKnownLocation = friendLocation)
 
     doAnswer { invocationOnMock ->
           val onSuccess = invocationOnMock.getArgument<(List<User>) -> Unit>(1)

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/MainActivityTest.kt
@@ -17,7 +17,6 @@ import com.swent.suddenbump.ui.utils.testableMeetingViewModel
 import com.swent.suddenbump.ui.utils.testableUserViewModel
 import io.mockk.invoke
 import kotlin.test.assertEquals
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/CalendarMeetingsTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/CalendarMeetingsTest.kt
@@ -57,7 +57,7 @@ class CalendarMeetingsScreenTest {
             phoneNumber = "+1234567890",
             profilePicture = null,
             emailAddress = "current@gmail.com",
-            lastKnownLocation = MutableStateFlow(Location("mock_provider")))
+            lastKnownLocation = Location("mock_provider"))
     val userFriends =
         listOf(
             User(
@@ -67,7 +67,7 @@ class CalendarMeetingsScreenTest {
                 "+12345678",
                 null,
                 "mike@example.com",
-                MutableStateFlow(Location("mock_provider"))),
+                Location("mock_provider")),
             User(
                 "friendId2",
                 "Joe",
@@ -75,7 +75,7 @@ class CalendarMeetingsScreenTest {
                 "+123456789",
                 null,
                 "joe@example.com",
-                MutableStateFlow(Location("mock_provider"))))
+                Location("mock_provider")))
 
     every { userViewModel.getUserFriends() } returns MutableStateFlow(userFriends)
     every { userViewModel.getCurrentUser() } returns MutableStateFlow(currentUser)

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/PendingMeetingsTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/calendar/PendingMeetingsTest.kt
@@ -75,7 +75,7 @@ class PendingMeetingsScreenTest {
             "+12345678",
             null,
             "user1@email.com",
-            MutableStateFlow(Location("mock_provider")))
+            Location("mock_provider"))
     val user2 =
         User(
             "creator2",
@@ -84,7 +84,7 @@ class PendingMeetingsScreenTest {
             "+123456789",
             null,
             "user2@email.com",
-            MutableStateFlow(Location("mock_provider")))
+            Location("mock_provider"))
 
     every { userViewModel.getUserFriends() } returns MutableStateFlow(listOf(user1, user2))
     every { userViewModel.getCurrentUser() } returns
@@ -96,7 +96,7 @@ class PendingMeetingsScreenTest {
                 "+1234567890",
                 null,
                 "current@gmail.com",
-                MutableStateFlow(Location("mock_provider"))))
+                Location("mock_provider")))
   }
 
   @Test

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/chat/ChatScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/chat/ChatScreenTest.kt
@@ -25,11 +25,10 @@ class ChatScreenTest {
   private lateinit var fakeNavigationActions: FakeNavigationActions
   private lateinit var mockNavController: NavHostController
   private val location =
-      MutableStateFlow(
-          Location("mock_provider").apply {
-            latitude = 0.0
-            longitude = 0.0
-          })
+      Location("dummy").apply {
+        latitude = 0.0
+        longitude = 0.0
+      }
 
   // **Set up method to initialize mocks before each test**
   @Before

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/contacts/AddContactTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/contacts/AddContactTest.kt
@@ -42,11 +42,10 @@ class AddContactScreenTest {
             profilePicture = null,
             emailAddress = "",
             lastKnownLocation =
-                MutableStateFlow(
-                    Location("mock_provider").apply {
-                      latitude = 46.5180
-                      longitude = 6.5680
-                    }))
+                Location("mock_provider").apply {
+                  latitude = 46.5180
+                  longitude = 6.5680
+                })
     val user1 =
         UserWithFriendsInCommon(
             user =
@@ -58,11 +57,10 @@ class AddContactScreenTest {
                     profilePicture = null,
                     emailAddress = "",
                     lastKnownLocation =
-                        MutableStateFlow(
-                            Location("mock_provider").apply {
-                              latitude = 46.5180
-                              longitude = 6.5680
-                            })),
+                        Location("mock_provider").apply {
+                          latitude = 46.5180
+                          longitude = 6.5680
+                        }),
             friendsInCommon = 2,
         )
     val user2 =
@@ -74,11 +72,10 @@ class AddContactScreenTest {
             profilePicture = null,
             emailAddress = "",
             lastKnownLocation =
-                MutableStateFlow(
-                    Location("mock_provider").apply {
-                      latitude = 46.5180
-                      longitude = 6.5681
-                    }))
+                Location("mock_provider").apply {
+                  latitude = 46.5180
+                  longitude = 6.5681
+                })
 
     every { navigationActions.currentRoute() } returns (Route.OVERVIEW)
     every { navigationActions.goBack() } returns Unit
@@ -160,11 +157,10 @@ class UserRowsTest {
             profilePicture = null,
             emailAddress = "",
             lastKnownLocation =
-                MutableStateFlow(
-                    Location("mock_provider").apply {
-                      latitude = 46.5180
-                      longitude = 6.5680
-                    }))
+                Location("mock_provider").apply {
+                  latitude = 46.5180
+                  longitude = 6.5680
+                })
 
     testUser =
         UserWithFriendsInCommon(
@@ -177,11 +173,10 @@ class UserRowsTest {
                     profilePicture = null,
                     emailAddress = "",
                     lastKnownLocation =
-                        MutableStateFlow(
-                            Location("mock_provider").apply {
-                              latitude = 46.5181
-                              longitude = 6.5681
-                            })),
+                        Location("mock_provider").apply {
+                          latitude = 46.5181
+                          longitude = 6.5681
+                        }),
             friendsInCommon = 2,
         )
 

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/contacts/ContactTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/contacts/ContactTest.kt
@@ -37,11 +37,10 @@ class ContactScreenTest {
               profilePicture = null,
               emailAddress = "",
               lastKnownLocation =
-                  MutableStateFlow(
-                      Location("mock_provider").apply {
-                        latitude = 46.5180
-                        longitude = 6.5680
-                      })))
+                  Location("dummy").apply {
+                    latitude = 46.5180
+                    longitude = 6.5680
+                  }))
   private val currentUser =
       MutableStateFlow(
           User(
@@ -52,11 +51,10 @@ class ContactScreenTest {
               profilePicture = null,
               emailAddress = "",
               lastKnownLocation =
-                  MutableStateFlow(
-                      Location("mock_provider").apply {
-                        latitude = 46.5180
-                        longitude = 6.5680
-                      })))
+                  Location("mock_provider").apply {
+                    latitude = 46.5180
+                    longitude = 6.5680
+                  }))
 
   @get:Rule val composeTestRule = createComposeRule()
 

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/destination/MapScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/destination/MapScreenTest.kt
@@ -14,7 +14,6 @@ import com.swent.suddenbump.model.user.UserViewModel
 import com.swent.suddenbump.ui.map.MapScreen
 import com.swent.suddenbump.ui.navigation.NavigationActions
 import com.swent.suddenbump.ui.navigation.TopLevelDestinations
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -35,11 +34,10 @@ class MapScreenTest {
 
   private val exception = Exception()
   private val location =
-      MutableStateFlow(
-          Location("mock_provider").apply {
-            latitude = 0.0
-            longitude = 0.0
-          })
+      Location("mock_provider").apply {
+        latitude = 0.0
+        longitude = 0.0
+      }
   private val user =
       User("1", "Martin", "Vetterli", "+41 00 000 00 01", null, "martin.vetterli@epfl.ch", location)
 

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/destination/SimpleMapTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/destination/SimpleMapTest.kt
@@ -9,7 +9,6 @@ import com.swent.suddenbump.model.user.User
 import com.swent.suddenbump.model.user.UserRepository
 import com.swent.suddenbump.model.user.UserViewModel
 import com.swent.suddenbump.ui.map.SimpleMap
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -25,11 +24,10 @@ class SimpleMapTest {
   private lateinit var meetingViewModel: MeetingViewModel
 
   private val location =
-      MutableStateFlow(
-          Location("mock_provider").apply {
-            latitude = 0.0
-            longitude = 0.0
-          })
+      Location("mock_provider").apply {
+        latitude = 0.0
+        longitude = 0.0
+      }
 
   private val user =
       User("1", "Martin", "Vetterli", "+41 00 000 00 01", null, "martin.vetterli@epfl.ch", location)

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/endToEndTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/endToEndTest.kt
@@ -43,7 +43,6 @@ import com.swent.suddenbump.ui.overview.SettingsScreen
 import io.mockk.every
 import io.mockk.invoke
 import io.mockk.mockk
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -147,7 +146,7 @@ class EndToEndTest2 {
             phoneNumber = "1234567890",
             profilePicture = null,
             emailAddress = "test.user@example.com",
-            lastKnownLocation = MutableStateFlow(userLocation))
+            lastKnownLocation = userLocation)
 
     val friend =
         User(
@@ -157,7 +156,7 @@ class EndToEndTest2 {
             phoneNumber = "0987654321",
             profilePicture = null,
             emailAddress = "friend.user@example.com",
-            lastKnownLocation = MutableStateFlow(friendLocation))
+            lastKnownLocation = friendLocation)
 
     // Mock getUserFriends to return a single friend
     every { mockFirestore.getUserFriends(any(), captureLambda(), any()) } answers

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/messages/MessagesScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/messages/MessagesScreenTest.kt
@@ -14,7 +14,6 @@ import com.swent.suddenbump.model.user.UserViewModel
 import com.swent.suddenbump.ui.navigation.NavigationActions
 import com.swent.suddenbump.ui.navigation.Route
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import org.junit.Before
 import org.junit.Rule
@@ -31,11 +30,10 @@ class MessagesScreenTest {
   private lateinit var flowMock: Flow<List<ChatSummary>>
 
   private val locationDummy =
-      MutableStateFlow(
-          Location("mock_provider").apply {
-            latitude = 0.0 // Set latitude
-            longitude = 0.0 // Set longitude
-          })
+      Location("mock_provider").apply {
+        latitude = 0.0 // Set latitude
+        longitude = 0.0 // Set longitude
+      }
 
   private val userDummy1 =
       User(

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/overview/BlockedUsersScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/overview/BlockedUsersScreenTest.kt
@@ -31,11 +31,10 @@ class BlockedUsersScreenTest {
 
     // Create a mock location
     val mockLocation =
-        MutableStateFlow(
-            Location("mock_provider").apply {
-              latitude = 46.5180
-              longitude = 6.5680
-            })
+        Location("mock_provider").apply {
+          latitude = 46.5180
+          longitude = 6.5680
+        }
 
     // Set up test users
     currentUser =

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/overview/MeetingsSettingsTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/overview/MeetingsSettingsTest.kt
@@ -42,7 +42,7 @@ class MeetingsSettingsTest {
                 phoneNumber = "+123456789",
                 profilePicture = null,
                 emailAddress = "john.doe@example.com",
-                lastKnownLocation = MutableStateFlow(Location("mock_provider"))))
+                lastKnownLocation = Location("mock_provider")))
   }
 
   @Test

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/overview/OverviewScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/overview/OverviewScreenTest.kt
@@ -46,7 +46,7 @@ class OverviewScreenTest {
           phoneNumber = "+1234567890",
           profilePicture = null,
           emailAddress = "john.doe@example.com",
-          lastKnownLocation = MutableStateFlow(location1))
+          lastKnownLocation = location1)
 
   private val user2 =
       User(
@@ -56,7 +56,7 @@ class OverviewScreenTest {
           phoneNumber = "+1234567891",
           profilePicture = ImageBitmap(100, 100),
           emailAddress = "jane.smith@example.com",
-          lastKnownLocation = MutableStateFlow(location2))
+          lastKnownLocation = location2)
 
   @Before
   fun setUp() {

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/overview/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/overview/SettingsScreenTest.kt
@@ -23,7 +23,6 @@ import com.swent.suddenbump.ui.navigation.NavigationActions
 import io.mockk.mockk
 import java.io.File
 import java.io.FileOutputStream
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -129,7 +128,7 @@ class SettingsScreenTest {
             phoneNumber = "+1234567890",
             profilePicture = ImageBitmap(100, 100),
             emailAddress = "test.user@example.com",
-            lastKnownLocation = MutableStateFlow(locationDummy))
+            lastKnownLocation = locationDummy)
     userViewModel.setUser(userWithProfilePicture, {}, {})
 
     setContentDefault()
@@ -160,7 +159,7 @@ class SettingsScreenTest {
             phoneNumber = "+1234567891",
             profilePicture = null,
             emailAddress = "test.user@example.com",
-            lastKnownLocation = MutableStateFlow(locationDummy))
+            lastKnownLocation = locationDummy)
     userViewModel.setUser(userWithoutProfilePicture, {}, {})
 
     setContentDefault()
@@ -180,7 +179,7 @@ class SettingsScreenTest {
             phoneNumber = "+1234567892",
             profilePicture = ImageBitmap(100, 100),
             emailAddress = "alice.brown@example.com",
-            lastKnownLocation = MutableStateFlow(locationDummy))
+            lastKnownLocation = locationDummy)
     userViewModel.setUser(userWithProfilePicture, {}, {})
 
     setContentDefault()
@@ -213,7 +212,7 @@ class SettingsScreenTest {
             phoneNumber = "+1234567893",
             profilePicture = ImageBitmap(100, 100),
             emailAddress = "bob.smith@example.com",
-            lastKnownLocation = MutableStateFlow(locationDummy))
+            lastKnownLocation = locationDummy)
     userViewModel.setUser(userWithProfilePicture, {}, {})
 
     composeTestRule.waitForIdle()
@@ -235,7 +234,7 @@ class SettingsScreenTest {
             phoneNumber = "+1234567890",
             profilePicture = null,
             emailAddress = "test.user@example.com",
-            lastKnownLocation = MutableStateFlow(locationDummy))
+            lastKnownLocation = locationDummy)
     userViewModel.setUser(initialUser, {}, {})
 
     // Create a mock Uri for the image
@@ -277,7 +276,7 @@ class SettingsScreenTest {
             phoneNumber = "+1234567890",
             profilePicture = null,
             emailAddress = "test.user@example.com",
-            lastKnownLocation = MutableStateFlow(locationDummy))
+            lastKnownLocation = locationDummy)
     userViewModel.setUser(initialUser, {}, {})
 
     // Act: Set up the screen and simulate the failure
@@ -309,7 +308,7 @@ class SettingsScreenTest {
             phoneNumber = "+1234567890",
             profilePicture = null,
             emailAddress = "test.user@example.com",
-            lastKnownLocation = MutableStateFlow(locationDummy))
+            lastKnownLocation = locationDummy)
     userViewModel.setUser(initialUser, {}, {})
 
     val context = ApplicationProvider.getApplicationContext<Context>()

--- a/app/src/main/java/com/swent/suddenbump/model/user/User.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/user/User.kt
@@ -2,7 +2,6 @@ package com.swent.suddenbump.model.user
 
 import android.location.Location
 import androidx.compose.ui.graphics.ImageBitmap
-import kotlinx.coroutines.flow.MutableStateFlow
 
 data class User(
     val uid: String,
@@ -11,7 +10,7 @@ data class User(
     val phoneNumber: String,
     val profilePicture: ImageBitmap?,
     val emailAddress: String,
-    val lastKnownLocation: MutableStateFlow<Location>,
+    val lastKnownLocation: Location,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true

--- a/app/src/main/java/com/swent/suddenbump/model/user/UserRepositoryFirestore.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/user/UserRepositoryFirestore.kt
@@ -23,7 +23,6 @@ import com.swent.suddenbump.model.image.ImageRepository
 import com.swent.suddenbump.model.image.ImageRepositoryFirebaseStorage
 import com.swent.suddenbump.worker.WorkerScheduler
 import java.util.concurrent.TimeUnit
-import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
  * A Firebase Firestore-backed implementation of the UserRepository interface, managing user
@@ -1048,9 +1047,7 @@ class UserRepositoryFirestore(
       friends: List<User>,
       radius: Double
   ): List<User> {
-    return friends.filter { friend ->
-      userLocation.distanceTo(friend.lastKnownLocation.value) <= radius
-    }
+    return friends.filter { friend -> userLocation.distanceTo(friend.lastKnownLocation) <= radius }
   }
 
   /**
@@ -1446,7 +1443,7 @@ class UserRepositoryFirestoreHelper {
         "lastName" to user.lastName,
         "phoneNumber" to user.phoneNumber,
         "emailAddress" to user.emailAddress,
-        "lastKnownLocation" to locationToString(user.lastKnownLocation.value))
+        "lastKnownLocation" to locationToString(user.lastKnownLocation))
   }
 
   /**
@@ -1544,7 +1541,7 @@ class UserRepositoryFirestoreHelper {
         phoneNumber = document.data?.get("phoneNumber").toString(),
         emailAddress = document.data?.get("emailAddress").toString(),
         profilePicture = profilePicture,
-        lastKnownLocation = MutableStateFlow(lastKnownLocation ?: Location("")),
+        lastKnownLocation = lastKnownLocation ?: Location(""),
     )
   }
 

--- a/app/src/main/java/com/swent/suddenbump/model/user/UserViewModel.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/user/UserViewModel.kt
@@ -46,11 +46,10 @@ open class UserViewModel(
   val friendsLocations = mutableStateOf<Map<User, Location?>>(emptyMap())
 
   private val locationDummy =
-      MutableStateFlow(
-          Location("dummy").apply {
-            latitude = 0.0 // Latitude fictive
-            longitude = 0.0 // Longitude fictive
-          })
+      Location("dummy").apply {
+        latitude = 0.0 // Latitude fictive
+        longitude = 0.0 // Longitude fictive
+      }
   val testUser =
       User(
           "h33lbxyJpcj4OZQAA4QM",
@@ -468,8 +467,8 @@ open class UserViewModel(
     repository.setBlockedFriends(user.uid, blockedFriendsList, onSuccess, onFailure)
   }
 
-  fun getLocation(): StateFlow<Location> {
-    return _user.value.lastKnownLocation.asStateFlow()
+  fun getLocation(): Location {
+    return _user.value.lastKnownLocation
   }
 
   /**
@@ -486,7 +485,7 @@ open class UserViewModel(
       onSuccess: () -> Unit,
       onFailure: (Exception) -> Unit
   ) {
-    _user.value.lastKnownLocation.value = location
+    _user.value.lastKnownLocation.set(location)
     repository.updateUserLocation(user.uid, location, onSuccess, onFailure)
   }
 
@@ -569,9 +568,9 @@ open class UserViewModel(
   }
 
   fun getRelativeDistance(friend: User): Float {
-    val userLocation = _user.value.lastKnownLocation.value
-    val friendLocation = friend.lastKnownLocation.value
-    if (userLocation == locationDummy.value || friendLocation == locationDummy.value) {
+    val userLocation = _user.value.lastKnownLocation
+    val friendLocation = friend.lastKnownLocation
+    if (userLocation == locationDummy || friendLocation == locationDummy) {
       return Float.MAX_VALUE
     }
     return userLocation.distanceTo(friendLocation)
@@ -581,8 +580,8 @@ open class UserViewModel(
   private val locationCache = mutableMapOf<String, String>()
 
   /** Fetches the city and country for a given location */
-  suspend fun getCityAndCountry(location: StateFlow<Location>): String {
-    val latLng = "${location.value.latitude},${location.value.longitude}"
+  suspend fun getCityAndCountry(location: Location): String {
+    val latLng = "${location.latitude},${location.longitude}"
 
     // Check cache first
     locationCache[latLng]?.let {
@@ -631,8 +630,7 @@ open class UserViewModel(
   fun isFriendsInRadius(radius: Int): Boolean {
     loadFriends()
     _userFriends.value.forEach { friend ->
-      if (_user.value.lastKnownLocation.value.distanceTo(friend.lastKnownLocation.value) <=
-          radius) {
+      if (_user.value.lastKnownLocation.distanceTo(friend.lastKnownLocation) <= radius) {
         return true
       }
     }

--- a/app/src/main/java/com/swent/suddenbump/ui/authentication/SignUp.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/authentication/SignUp.kt
@@ -39,7 +39,6 @@ import com.swent.suddenbump.ui.theme.PurpleGrey40
 import com.swent.suddenbump.ui.utils.PhoneNumberVisualTransformation
 import com.yalantis.ucrop.UCrop
 import java.io.File
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
 /**
@@ -75,13 +74,12 @@ fun SignUpScreen(navigationActions: NavigationActions, userViewModel: UserViewMo
   // Coroutine scope for launching coroutines
   val coroutineScope = rememberCoroutineScope()
 
-  // StateFlow for base location
+  // base location
   val baseLocation =
-      MutableStateFlow(
-          Location("providerName").apply {
-            latitude = 0.0
-            longitude = 0.0
-          })
+      Location("incomplete").apply {
+        latitude = 0.0
+        longitude = 0.0
+      }
 
   // LiveData for verification status
   val verificationStatus by userViewModel.verificationStatus.observeAsState()

--- a/app/src/main/java/com/swent/suddenbump/ui/map/Map.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/map/Map.kt
@@ -100,7 +100,7 @@ fun SimpleMap(
 ) {
   // Initialize necessary variables and states
   val context = LocalContext.current
-  val markerState = rememberMarkerState(position = LatLng(0.0, 0.0))
+  val markerState = rememberMarkerState(position = LatLng(100.0, 200.0))
   val cameraPositionState = rememberCameraPositionState()
   var zoomDone by remember { mutableStateOf(false) }
   var selectedLocation by remember { mutableStateOf<LatLng?>(null) }
@@ -127,12 +127,15 @@ fun SimpleMap(
   // Update user location and camera position
   LaunchedEffect(userViewModel.getLocation()) {
     userViewModel.getLocation().let {
-      val latLng = LatLng(it.value.latitude, it.value.longitude)
-      markerState.position = latLng
-      if (!zoomDone) {
-        cameraPositionState.position = CameraPosition.fromLatLngZoom(latLng, 13f)
-        fetchLocationToServer(it.value, userViewModel)
-        zoomDone = true
+      Log.d("LocationUpdate", "Location updated provider: ${it.provider}")
+      if (it.provider == "fused" || it.provider == "GPS") {
+        val latLng = LatLng(it.latitude, it.longitude)
+        markerState.position = latLng
+        if (!zoomDone) {
+          cameraPositionState.position = CameraPosition.fromLatLngZoom(latLng, 13f)
+          fetchLocationToServer(it, userViewModel)
+          zoomDone = true
+        }
       }
     }
   }
@@ -265,8 +268,10 @@ fun FriendsMarkers(userViewModel: UserViewModel, onFriendMarkerInfoWindowClick: 
 
   // Initialize marker states for each friend
   friends.forEach { friend ->
-    val friendLatLng =
-        LatLng(friend.lastKnownLocation.value.latitude, friend.lastKnownLocation.value.longitude)
+    if (!(friend.lastKnownLocation.provider == "fused" ||
+        friend.lastKnownLocation.provider == "GPS"))
+        return@forEach
+    val friendLatLng = LatLng(friend.lastKnownLocation.latitude, friend.lastKnownLocation.longitude)
     if (!markerStates.containsKey(friend.uid)) {
       markerStates[friend.uid] = MarkerState(position = friendLatLng)
     } else {
@@ -277,6 +282,7 @@ fun FriendsMarkers(userViewModel: UserViewModel, onFriendMarkerInfoWindowClick: 
   }
 
   friends.forEach { friend ->
+    if (friend.lastKnownLocation.provider == "incomplete") return@forEach
     val markerState = markerStates[friend.uid] ?: return@forEach
 
     // Show info window with friend's name when marker is clicked

--- a/app/src/main/java/com/swent/suddenbump/ui/overview/FriendsList.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/overview/FriendsList.kt
@@ -61,7 +61,7 @@ fun UserCard(user: User, navigationActions: NavigationActions, userViewModel: Us
         Text(text = "Phone: ${user.phoneNumber}")
         Text(
             text =
-                "latitude: ${user.lastKnownLocation.value.latitude}, longitude: ${user.lastKnownLocation.value.longitude}")
+                "latitude: ${user.lastKnownLocation.latitude}, longitude: ${user.lastKnownLocation.longitude}")
       }
     }
   }

--- a/app/src/main/java/com/swent/suddenbump/worker/LocationUpdateWorker.kt
+++ b/app/src/main/java/com/swent/suddenbump/worker/LocationUpdateWorker.kt
@@ -86,6 +86,9 @@ class LocationUpdateWorker(
                       repository.userFriendsInRadius(
                           userLocation = location, friends = friends, radius = radius.toDouble())
                   friendsInRadius.forEach { friend ->
+                    if (!(friend.lastKnownLocation.provider == "fused" ||
+                        friend.lastKnownLocation.provider == "GPS"))
+                        return@forEach
                     if (friend.uid !in alreadyNotifiedFriends) {
                       Log.d("WorkerSuddenBump", "alreadyNotifiedFriends: $alreadyNotifiedFriends")
                       showFriendNearbyNotification(applicationContext, user.uid, friend)

--- a/app/src/test/java/com/swent/suddenbump/model/NotificationTest.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/NotificationTest.kt
@@ -15,7 +15,6 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.GregorianCalendar
 import java.util.Locale
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -31,11 +30,10 @@ class NotificationTest {
   fun testShowFriendNearbyNotification() {
 
     val locationDummy =
-        MutableStateFlow(
-            Location("dummy").apply {
-              latitude = 0.0 // Latitude fictive
-              longitude = 0.0 // Longitude fictive
-            })
+        Location("dummy").apply {
+          latitude = 0.0 // Latitude fictive
+          longitude = 0.0 // Longitude fictive
+        }
 
     val userDummy1 =
         User(

--- a/app/src/test/java/com/swent/suddenbump/model/chat/ChatSummaryTest.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/chat/ChatSummaryTest.kt
@@ -3,7 +3,6 @@ package com.swent.suddenbump.model.chat
 import android.location.Location
 import com.google.firebase.firestore.*
 import com.swent.suddenbump.model.user.User
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.After
 import org.junit.Assert.*
 import org.junit.Before
@@ -16,11 +15,10 @@ class ChatSummaryTest {
   private val participants = listOf("uidUser1", "uidUser2")
 
   private val locationDummy =
-      MutableStateFlow(
-          Location("mock_provider").apply {
-            latitude = 0.0 // Set latitude
-            longitude = 0.0 // Set longitude
-          })
+      Location("mock_provider").apply {
+        latitude = 0.0 // Set latitude
+        longitude = 0.0 // Set longitude
+      }
 
   private val userDummy1 =
       User(

--- a/app/src/test/java/com/swent/suddenbump/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/user/UserViewModelTest.kt
@@ -16,7 +16,6 @@ import junit.framework.TestCase.assertFalse
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -32,7 +31,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.`when`
 import org.mockito.kotlin.any
@@ -54,11 +52,10 @@ class UserViewModelTest {
 
   private val exception = Exception()
   private val location =
-      MutableStateFlow(
-          Location("mock_provider").apply {
-            latitude = 0.0
-            longitude = 0.0
-          })
+      Location("mock_provider").apply {
+        latitude = 0.0
+        longitude = 0.0
+      }
   private val user =
       User("2", "Martin", "Vetterli", "+41 00 000 00 01", null, "martin.vetterli@epfl.ch", location)
 
@@ -161,7 +158,7 @@ class UserViewModelTest {
             phoneNumber = "+41 00 000 00 01",
             profilePicture = null,
             emailAddress = "current.user@example.com",
-            lastKnownLocation = MutableStateFlow(Location("mock_provider")))
+            lastKnownLocation = Location("mock_provider"))
 
     val friend =
         User(
@@ -171,7 +168,7 @@ class UserViewModelTest {
             phoneNumber = "+41 00 000 00 02",
             profilePicture = null,
             emailAddress = "friend.user@example.com",
-            lastKnownLocation = MutableStateFlow(Location("mock_provider")))
+            lastKnownLocation = Location("mock_provider"))
 
     // Set current user in the ViewModel
     userViewModel.setUser(currentUser, onSuccess = {}, onFailure = {})
@@ -238,7 +235,7 @@ class UserViewModelTest {
             phoneNumber = "+41 00 000 00 01",
             profilePicture = null,
             emailAddress = "current.user@example.com",
-            lastKnownLocation = MutableStateFlow(Location("mock_provider")))
+            lastKnownLocation = Location("mock_provider"))
 
     val friend =
         User(
@@ -248,7 +245,7 @@ class UserViewModelTest {
             phoneNumber = "+41 00 000 00 02",
             profilePicture = null,
             emailAddress = "friend.user@example.com",
-            lastKnownLocation = MutableStateFlow(Location("mock_provider")))
+            lastKnownLocation = Location("mock_provider"))
 
     // Set current user in the ViewModel
     userViewModel.setUser(currentUser, onSuccess = {}, onFailure = {})
@@ -669,7 +666,7 @@ class UserViewModelTest {
             "+1234567890",
             null,
             "john.doe@example.com",
-            MutableStateFlow(Location("mock_provider")))
+            Location("mock_provider"))
     val blockedUser =
         User(
             "2",
@@ -678,7 +675,7 @@ class UserViewModelTest {
             "+0987654321",
             null,
             "jane.doe@example.com",
-            MutableStateFlow(Location("mock_provider")))
+            Location("mock_provider"))
 
     var onSuccessCalled = false
     var onFailureCalled = false
@@ -732,22 +729,22 @@ class UserViewModelTest {
           longitude = 0.0
         }
 
-    assertThat(userViewModel.getLocation().value.latitude, `is`(0.0))
-    assertThat(userViewModel.getLocation().value.longitude, `is`(0.0))
+    assertThat(userViewModel.getLocation().latitude, `is`(0.0))
+    assertThat(userViewModel.getLocation().longitude, `is`(0.0))
   }
 
   @Test
   fun updateLocation() {
-    val mockLocation = Mockito.mock(Location::class.java)
-
-    // Set up the mock to return specific values
-    Mockito.`when`(mockLocation.latitude).thenReturn(1.0)
-    Mockito.`when`(mockLocation.longitude).thenReturn(1.0)
+    val mockLocation =
+        Location("mock_provider").apply {
+          latitude = 1.0
+          longitude = 1.0
+        }
 
     userViewModel.updateLocation(location = mockLocation, onSuccess = {}, onFailure = {})
     verify(userRepository).updateUserLocation(any(), any(), any(), any())
-    assertThat(userViewModel.getLocation().value.latitude, `is`(1.0))
-    assertThat(userViewModel.getLocation().value.longitude, `is`(1.0))
+    assertThat(userViewModel.getLocation().latitude, `is`(1.0))
+    assertThat(userViewModel.getLocation().longitude, `is`(1.0))
   }
 
   @Test
@@ -760,11 +757,10 @@ class UserViewModelTest {
   fun loadFriends_success() {
 
     val friendLocation =
-        MutableStateFlow(
-            Location("mock_provider").apply {
-              latitude = 1.0
-              longitude = 1.0
-            })
+        Location("mock_provider").apply {
+          latitude = 1.0
+          longitude = 1.0
+        }
 
     // Arrange
     val friend =
@@ -817,14 +813,13 @@ class UserViewModelTest {
     // Arrange
     userViewModel.setUser(user, {}, {})
     val friendLocation =
-        MutableStateFlow(
-            Location("mock_provider").apply {
-              latitude = 1.0
-              longitude = 1.0
-            })
+        Location("mock_provider").apply {
+          latitude = 1.0
+          longitude = 1.0
+        }
     val friend =
         User("2", "Jane", "Doe", "+41 00 000 00 02", null, "jane.doe@example.com", friendLocation)
-    val friendsMap = mapOf(friend to friendLocation.value)
+    val friendsMap = mapOf(friend to friendLocation)
 
     // Mock repository method for loading friend locations
     whenever(userRepository.getUserFriends(any(), any(), any())).thenAnswer {
@@ -833,7 +828,7 @@ class UserViewModelTest {
     }
 
     // Update the user location
-    userViewModel.updateLocation(friend, friendLocation.value, onSuccess = {}, onFailure = {})
+    userViewModel.updateLocation(friend, friendLocation, onSuccess = {}, onFailure = {})
 
     // Act
     val distance = userViewModel.getRelativeDistance(friend)
@@ -847,7 +842,7 @@ class UserViewModelTest {
   @Test
   fun getRelativeDistance_unknownFriendLocation() {
     // Arrange
-    userViewModel.updateLocation(location = location.value, onSuccess = {}, onFailure = {})
+    userViewModel.updateLocation(location = location, onSuccess = {}, onFailure = {})
 
     val friend =
         User("2", "Jane", "Doe", "+41 00 000 00 02", null, "jane.doe@example.com", location)
@@ -863,15 +858,14 @@ class UserViewModelTest {
   fun getRelativeDistance_noUserLocation() {
     // Arrange
     val friendLocation =
-        MutableStateFlow(
-            Location("mock_provider").apply {
-              latitude = 1.0
-              longitude = 1.0
-            })
+        Location("mock_provider").apply {
+          latitude = 1.0
+          longitude = 1.0
+        }
     val friend =
         User("2", "Jane", "Doe", "+41 00 000 00 02", null, "jane.doe@example.com", friendLocation)
 
-    userViewModel.updateLocation(friend, friendLocation.value, onSuccess = {}, onFailure = {})
+    userViewModel.updateLocation(friend, friendLocation, onSuccess = {}, onFailure = {})
 
     // Act
     val distance = userViewModel.getRelativeDistance(friend)
@@ -1100,7 +1094,7 @@ class UserViewModelTest {
             "+41789123450",
             null,
             "current.user@example.com",
-            MutableStateFlow(Location("mock_provider")))
+            Location("mock_provider"))
     val blockedUser =
         User(
             "blocked_id",
@@ -1109,7 +1103,7 @@ class UserViewModelTest {
             "+41789123456",
             null,
             "blocked.user@example.com",
-            MutableStateFlow(Location("mock_provider")))
+            Location("mock_provider"))
 
     // Set current user
     userViewModel.setUser(currentUser, {}, {})
@@ -1167,7 +1161,7 @@ class UserViewModelTest {
             "+41789123450",
             null,
             "current.user@example.com",
-            MutableStateFlow(Location("mock_provider")))
+            Location("mock_provider"))
     val blockedUser =
         User(
             "blocked_id",
@@ -1176,7 +1170,7 @@ class UserViewModelTest {
             "+41789123456",
             null,
             "blocked.user@example.com",
-            MutableStateFlow(Location("mock_provider")))
+            Location("mock_provider"))
     val error = Exception("Failed to unblock user")
 
     // Set current user

--- a/app/src/test/java/com/swent/suddenbump/model/user/UserViewModelTest.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/user/UserViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.swent.suddenbump.model.user
 
 import android.location.Location
-import android.util.Log
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Observer
@@ -16,6 +15,7 @@ import junit.framework.TestCase.assertFalse
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -49,6 +49,7 @@ class UserViewModelTest {
   private lateinit var userRepository: UserRepository
   private lateinit var userViewModel: UserViewModel
   private lateinit var chatRepository: ChatRepository
+  private val mutableState = MutableStateFlow(0)
 
   private val exception = Exception()
   private val location =

--- a/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/BlockedUserTests.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/BlockedUserTests.kt
@@ -23,7 +23,6 @@ import com.swent.suddenbump.worker.WorkerScheduler
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import junit.framework.TestCase.fail
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -96,11 +95,10 @@ class BlockedUserTests {
   val snapshot2: DocumentSnapshot = mock(DocumentSnapshot::class.java)
 
   private val location =
-      MutableStateFlow(
-          Location("mock_provider").apply {
-            latitude = 0.0
-            longitude = 0.0
-          })
+      Location("mock_provider").apply {
+        latitude = 0.0
+        longitude = 0.0
+      }
   private val user =
       User(
           uid = "1",

--- a/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/MiscellaneousTests.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/MiscellaneousTests.kt
@@ -27,7 +27,6 @@ import com.swent.suddenbump.worker.WorkerScheduler
 import junit.framework.TestCase.assertTrue
 import kotlin.reflect.full.declaredFunctions
 import kotlin.reflect.jvm.isAccessible
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -103,11 +102,10 @@ class MiscellaneousTests {
   val snapshot2: DocumentSnapshot = mock(DocumentSnapshot::class.java)
 
   private val location =
-      MutableStateFlow(
-          Location("mock_provider").apply {
-            latitude = 0.0
-            longitude = 0.0
-          })
+      Location("mock_provider").apply {
+        latitude = 0.0
+        longitude = 0.0
+      }
   private val user =
       User(
           uid = "1",
@@ -239,7 +237,7 @@ class MiscellaneousTests {
     `when`(mockUserDocumentReference.update(anyString(), any())).thenReturn(mockTaskVoid)
 
     userRepositoryFirestore.updateUserLocation(
-        uid = user.uid, location = location.value, onSuccess = {}, onFailure = {})
+        uid = user.uid, location = location, onSuccess = {}, onFailure = {})
 
     shadowOf(Looper.getMainLooper()).idle()
 

--- a/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/PhoneNumberTests.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/PhoneNumberTests.kt
@@ -30,7 +30,6 @@ import com.swent.suddenbump.model.user.UserRepositoryFirestoreHelper
 import com.swent.suddenbump.worker.WorkerScheduler
 import junit.framework.TestCase.assertTrue
 import junit.framework.TestCase.fail
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -111,11 +110,10 @@ class PhoneNumberTests {
   val snapshot2: DocumentSnapshot = mock(DocumentSnapshot::class.java)
 
   private val location =
-      MutableStateFlow(
-          Location("mock_provider").apply {
-            latitude = 0.0
-            longitude = 0.0
-          })
+      Location("mock_provider").apply {
+        latitude = 0.0
+        longitude = 0.0
+      }
   private val user =
       User(
           uid = "1",

--- a/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/RadiusNotifsTests.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/RadiusNotifsTests.kt
@@ -20,7 +20,6 @@ import com.swent.suddenbump.model.user.SharedPreferencesManager
 import com.swent.suddenbump.model.user.User
 import com.swent.suddenbump.model.user.UserRepositoryFirestore
 import com.swent.suddenbump.worker.WorkerScheduler
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -96,11 +95,10 @@ class RadiusNotifsTests {
   val snapshot2: DocumentSnapshot = mock(DocumentSnapshot::class.java)
 
   private val location =
-      MutableStateFlow(
-          Location("mock_provider").apply {
-            latitude = 0.0
-            longitude = 0.0
-          })
+      Location("mock_provider").apply {
+        latitude = 0.0
+        longitude = 0.0
+      }
   private val user =
       User(
           uid = "1",
@@ -250,9 +248,9 @@ class RadiusNotifsTests {
           longitude = -118.243683
         }
 
-    val friend1 = user.copy(lastKnownLocation = MutableStateFlow(friend1Location))
-    val friend2 = user.copy(lastKnownLocation = MutableStateFlow(friend2Location))
-    val friend3 = user.copy(lastKnownLocation = MutableStateFlow(friend3Location))
+    val friend1 = user.copy(lastKnownLocation = friend1Location)
+    val friend2 = user.copy(lastKnownLocation = friend2Location)
+    val friend3 = user.copy(lastKnownLocation = friend3Location)
 
     val friends = listOf(friend1, friend2, friend3)
     val radius = 5000.0 // 5 kilometers

--- a/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/RecommendedFriendsTests.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/RecommendedFriendsTests.kt
@@ -21,7 +21,6 @@ import com.swent.suddenbump.model.user.UserRepositoryFirestore
 import com.swent.suddenbump.worker.WorkerScheduler
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.fail
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -90,11 +89,10 @@ class RecommendedFriendsTests {
   val snapshot2: DocumentSnapshot = mock(DocumentSnapshot::class.java)
 
   private val location =
-      MutableStateFlow(
-          Location("mock_provider").apply {
-            latitude = 0.0
-            longitude = 0.0
-          })
+      Location("mock_provider").apply {
+        latitude = 0.0
+        longitude = 0.0
+      }
   private val user =
       User(
           uid = "1",

--- a/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/ShareLocationTests.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/ShareLocationTests.kt
@@ -25,7 +25,6 @@ import com.swent.suddenbump.worker.WorkerScheduler
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertTrue
 import junit.framework.TestCase.fail
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -101,11 +100,10 @@ class ShareLocationTests {
   val snapshot2: DocumentSnapshot = mock(DocumentSnapshot::class.java)
 
   private val location =
-      MutableStateFlow(
-          Location("mock_provider").apply {
-            latitude = 0.0
-            longitude = 0.0
-          })
+      Location("mock_provider").apply {
+        latitude = 0.0
+        longitude = 0.0
+      }
   private val user =
       User(
           uid = "1",

--- a/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/UserAccountTests.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/UserAccountTests.kt
@@ -29,7 +29,6 @@ import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertTrue
 import junit.framework.TestCase.fail
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -109,11 +108,10 @@ class UserAccountTests {
   val snapshot2: DocumentSnapshot = mock(DocumentSnapshot::class.java)
 
   private val location =
-      MutableStateFlow(
-          Location("mock_provider").apply {
-            latitude = 0.0
-            longitude = 0.0
-          })
+      Location("mock_provider").apply {
+        latitude = 0.0
+        longitude = 0.0
+      }
   private val user =
       User(
           uid = "1",
@@ -296,7 +294,7 @@ class UserAccountTests {
                 phoneNumber = "+1234567890",
                 profilePicture = profilePicture,
                 emailAddress = email,
-                lastKnownLocation = MutableStateFlow(Location("mock_provider"))))
+                lastKnownLocation = Location("mock_provider")))
 
     // Inject mocked helper into userRepositoryFirestore
     val helperField = UserRepositoryFirestore::class.java.getDeclaredField("helper")
@@ -542,7 +540,7 @@ class UserAccountTests {
                 phoneNumber = "+1234567890",
                 profilePicture = profilePicture,
                 emailAddress = email,
-                lastKnownLocation = MutableStateFlow(Location("mock_provider"))))
+                lastKnownLocation = Location("mock_provider")))
 
     // Inject mocked helper into userRepositoryFirestore
     val helperField = UserRepositoryFirestore::class.java.getDeclaredField("helper")

--- a/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/UserFriendsRequestsTests.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/UserFriendsRequestsTests.kt
@@ -26,7 +26,6 @@ import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertTrue
 import junit.framework.TestCase.fail
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -99,11 +98,10 @@ class UserFriendsRequestsTests {
   val snapshot2: DocumentSnapshot = mock(DocumentSnapshot::class.java)
 
   private val location =
-      MutableStateFlow(
-          Location("mock_provider").apply {
-            latitude = 0.0
-            longitude = 0.0
-          })
+      Location("mock_provider").apply {
+        latitude = 0.0
+        longitude = 0.0
+      }
   private val user =
       User(
           uid = "1",

--- a/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/UserFriendsTests.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/UserFriendsTests.kt
@@ -114,11 +114,10 @@ class UserFriendsTests {
   val snapshot2: DocumentSnapshot = mock(DocumentSnapshot::class.java)
 
   private val location =
-      MutableStateFlow(
-          Location("mock_provider").apply {
-            latitude = 0.0
-            longitude = 0.0
-          })
+      Location("mock_provider").apply {
+        latitude = 0.0
+        longitude = 0.0
+      }
   private val user =
       User(
           uid = "1",

--- a/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/UserStatusTests.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/UserStatusTests.kt
@@ -20,7 +20,6 @@ import com.swent.suddenbump.worker.WorkerScheduler
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertTrue
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -75,11 +74,10 @@ class UserStatusTests {
   private lateinit var userRepositoryFirestore: UserRepositoryFirestore
 
   private val location =
-      MutableStateFlow(
-          Location("mock_provider").apply {
-            latitude = 0.0
-            longitude = 0.0
-          })
+      Location("mock_provider").apply {
+        latitude = 0.0
+        longitude = 0.0
+      }
   private val user =
       User(
           uid = "1",

--- a/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/VerifyNoAccountExistsTests.kt
+++ b/app/src/test/java/com/swent/suddenbump/model/user/userRepositoryFirestoreTests/VerifyNoAccountExistsTests.kt
@@ -23,7 +23,6 @@ import com.swent.suddenbump.model.user.UserRepositoryFirestore
 import com.swent.suddenbump.worker.WorkerScheduler
 import junit.framework.TestCase.assertTrue
 import junit.framework.TestCase.fail
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -98,11 +97,10 @@ class VerifyNoAccountExistsTests {
   val snapshot2: DocumentSnapshot = mock(DocumentSnapshot::class.java)
 
   private val location =
-      MutableStateFlow(
-          Location("mock_provider").apply {
-            latitude = 0.0
-            longitude = 0.0
-          })
+      Location("mock_provider").apply {
+        latitude = 0.0
+        longitude = 0.0
+      }
   private val user =
       User(
           uid = "1",


### PR DESCRIPTION
fix the problem with the default location where two friends "in" (0,0) could be considered by the app as close to each other. This case occurs when not authorizing the location retrieval. Remove the MutableStateFlow around the Location instances as it was useless