### PR TITLE
Delete friend cleanup blocked list and contact screen update

### DIFF
--- a/app/src/androidTest/java/com/swent/suddenbump/ui/contacts/ContactTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/contacts/ContactTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import com.swent.suddenbump.model.meeting.MeetingViewModel
 import com.swent.suddenbump.model.user.User
 import com.swent.suddenbump.model.user.UserViewModel
 import com.swent.suddenbump.ui.contact.ContactScreen
@@ -25,6 +26,7 @@ import org.junit.Test
 class ContactScreenTest {
   private lateinit var navigationActions: NavigationActions
   private lateinit var userViewModel: UserViewModel
+  private lateinit var meetingViewModel: MeetingViewModel
 
   private val friend =
       MutableStateFlow(
@@ -61,6 +63,7 @@ class ContactScreenTest {
   fun setUp() {
     navigationActions = mockk(relaxed = true)
     userViewModel = mockk(relaxed = true)
+    meetingViewModel = mockk(relaxed = true)
 
     every { navigationActions.currentRoute() } returns Route.OVERVIEW
 
@@ -74,7 +77,7 @@ class ContactScreenTest {
 
   @Test
   fun testInitialScreenState() {
-    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel, meetingViewModel) }
 
     composeTestRule.onNodeWithTag("contactScreen").assertIsDisplayed()
     composeTestRule.onNodeWithText("Contact").assertIsDisplayed()
@@ -92,7 +95,7 @@ class ContactScreenTest {
 
   @Test
   fun testNavigationBackButton() {
-    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel, meetingViewModel) }
     composeTestRule.waitForIdle()
 
     // Verify the back button is displayed
@@ -104,7 +107,7 @@ class ContactScreenTest {
 
   @Test
   fun testSendMessageButtonClick() {
-    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel, meetingViewModel) }
 
     composeTestRule.onNodeWithTag("sendMessageButton").assertIsDisplayed().performClick()
 
@@ -129,7 +132,7 @@ class ContactScreenTest {
         }
 
     // Act
-    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel, meetingViewModel) }
 
     // The "Requested" button should be displayed since it's a sent friend request scenario
     composeTestRule.onNodeWithTag("unsendFriendRequestButton").assertIsDisplayed()
@@ -156,7 +159,7 @@ class ContactScreenTest {
     every { userViewModel.getUserFriendRequests() } returns MutableStateFlow(listOf(friend.value))
     every { userViewModel.getSentFriendRequests() } returns MutableStateFlow(emptyList())
 
-    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel, meetingViewModel) }
 
     composeTestRule.onNodeWithText("Accept friend request").assertIsDisplayed()
     composeTestRule.onNodeWithText("Decline friend request").assertIsDisplayed()
@@ -169,7 +172,7 @@ class ContactScreenTest {
     every { userViewModel.getUserFriendRequests() } returns MutableStateFlow(emptyList())
     every { userViewModel.getSentFriendRequests() } returns MutableStateFlow(listOf(friend.value))
 
-    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel, meetingViewModel) }
 
     // Now should show "Requested" button with testTag "unsendFriendRequestButton"
     composeTestRule.onNodeWithTag("unsendFriendRequestButton").assertIsDisplayed()
@@ -182,7 +185,7 @@ class ContactScreenTest {
     every { userViewModel.getUserFriendRequests() } returns MutableStateFlow(emptyList())
     every { userViewModel.getSentFriendRequests() } returns MutableStateFlow(emptyList())
 
-    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel, meetingViewModel) }
 
     // Should show "Send Friend Request"
     composeTestRule.onNodeWithTag("addToContactsButton").assertIsDisplayed()
@@ -191,7 +194,7 @@ class ContactScreenTest {
 
   @Test
   fun testBlockUserDialog() {
-    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel, meetingViewModel) }
 
     composeTestRule.onNodeWithTag("moreOptionsButton").assertIsDisplayed().performClick()
 
@@ -204,7 +207,7 @@ class ContactScreenTest {
 
   @Test
   fun testBlockUserDialogDismiss() {
-    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel, meetingViewModel) }
 
     composeTestRule.onNodeWithTag("moreOptionsButton").assertIsDisplayed().performClick()
     composeTestRule.onNodeWithTag("blockUserButton").assertIsDisplayed().performClick()
@@ -224,7 +227,7 @@ class ContactScreenTest {
 
     every { userViewModel.getSelectedContact() } returns userCopiedFlow
 
-    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel, meetingViewModel) }
     composeTestRule.waitForIdle()
 
     // Verify the profile picture image
@@ -245,7 +248,7 @@ class ContactScreenTest {
           lambda<() -> Unit>().invoke() // Immediately call onSuccess
         }
 
-    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel, meetingViewModel) }
 
     // Open menu and delete friend
     composeTestRule.onNodeWithTag("moreOptionsButton").performClick()
@@ -265,7 +268,7 @@ class ContactScreenTest {
           user = any(), friend = any(), onSuccess = captureLambda(), onFailure = any())
     } answers { lambda<() -> Unit>().invoke() }
 
-    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel, meetingViewModel) }
 
     // Accept friend request
     composeTestRule.onNodeWithText("Accept friend request").performClick()
@@ -283,7 +286,7 @@ class ContactScreenTest {
           user = any(), friend = any(), onSuccess = captureLambda(), onFailure = any())
     } answers { lambda<() -> Unit>().invoke() }
 
-    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel, meetingViewModel) }
 
     // Decline friend request
     composeTestRule.onNodeWithText("Decline friend request").performClick()
@@ -301,7 +304,7 @@ class ContactScreenTest {
           user = any(), blockedUser = any(), onSuccess = captureLambda(), onFailure = any())
     } answers { lambda<() -> Unit>().invoke() }
 
-    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel, meetingViewModel) }
 
     // Open dialog to block user
     composeTestRule.onNodeWithTag("moreOptionsButton").performClick()
@@ -319,7 +322,7 @@ class ContactScreenTest {
     every { userViewModel.getUserFriendRequests() } returns MutableStateFlow(emptyList())
     every { userViewModel.getSentFriendRequests() } returns MutableStateFlow(emptyList())
 
-    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel) }
+    composeTestRule.setContent { ContactScreen(navigationActions, userViewModel, meetingViewModel) }
 
     // Open the dropdown menu
     composeTestRule.onNodeWithTag("moreOptionsButton").performClick()

--- a/app/src/androidTest/java/com/swent/suddenbump/ui/endToEndTest.kt
+++ b/app/src/androidTest/java/com/swent/suddenbump/ui/endToEndTest.kt
@@ -226,7 +226,9 @@ class EndToEndTests2and3 {
           composable(Screen.SETTINGS) {
             SettingsScreen(navigationActions, userViewModel, meetingViewModel)
           }
-          composable(Screen.CONTACT) { ContactScreen(navigationActions, userViewModel) }
+          composable(Screen.CONTACT) {
+            ContactScreen(navigationActions, userViewModel, meetingViewModel)
+          }
           composable(Screen.CHAT) { ChatScreen(userViewModel, navigationActions) }
           composable(Screen.ADD_MEETING) {
             AddMeetingScreen(navigationActions, userViewModel, meetingViewModel)
@@ -320,7 +322,9 @@ class EndToEndTests2and3 {
           }
           composable(Screen.ACCOUNT) { AccountScreen(navigationActions, userViewModel) }
           composable(Screen.BLOCKED_USERS) { BlockedUsersScreen(navigationActions, userViewModel) }
-          composable(Screen.CONTACT) { ContactScreen(navigationActions, userViewModel) }
+          composable(Screen.CONTACT) {
+            ContactScreen(navigationActions, userViewModel, meetingViewModel)
+          }
           composable(Screen.CHAT) { ChatScreen(userViewModel, navigationActions) }
           composable(Screen.ADD_MEETING) {
             AddMeetingScreen(navigationActions, userViewModel, meetingViewModel, locationViewModel)
@@ -518,7 +522,9 @@ class EndToEndTest4 {
           composable(Screen.SETTINGS) {
             SettingsScreen(navigationActions, userViewModel, meetingViewModel)
           }
-          composable(Screen.CONTACT) { ContactScreen(navigationActions, userViewModel) }
+          composable(Screen.CONTACT) {
+            ContactScreen(navigationActions, userViewModel, meetingViewModel)
+          }
           composable(Screen.CHAT) { ChatScreen(userViewModel, navigationActions) }
           composable(Screen.ADD_MEETING) {
             AddMeetingScreen(navigationActions, userViewModel, meetingViewModel)

--- a/app/src/main/java/com/swent/suddenbump/MainActivity.kt
+++ b/app/src/main/java/com/swent/suddenbump/MainActivity.kt
@@ -292,7 +292,9 @@ class MainActivity : ComponentActivity() {
         }
         composable(Screen.ACCOUNT) { AccountScreen(navigationActions, userViewModel) }
         composable(Screen.BLOCKED_USERS) { BlockedUsersScreen(navigationActions, userViewModel) }
-        composable(Screen.CONTACT) { ContactScreen(navigationActions, userViewModel) }
+        composable(Screen.CONTACT) {
+          ContactScreen(navigationActions, userViewModel, meetingViewModel)
+        }
         composable(Screen.CHAT) { ChatScreen(userViewModel, navigationActions) }
         composable(Screen.ADD_MEETING) {
           AddMeetingScreen(navigationActions, userViewModel, meetingViewModel, locationViewModel)

--- a/app/src/main/java/com/swent/suddenbump/model/meeting/MeetingViewModel.kt
+++ b/app/src/main/java/com/swent/suddenbump/model/meeting/MeetingViewModel.kt
@@ -142,4 +142,20 @@ open class MeetingViewModel(private val repositoryMeeting: MeetingRepository) : 
       }
     }
   }
+  /**
+   * Deletes all meetings with a specific friend ID.
+   *
+   * @param friendId The ID of the friend whose meetings are to be deleted.
+   * @param currentUserID The ID of the current user.
+   */
+  fun deleteAllMeetingsWithSpecificFriend(friendId: String, currentUserID: String) {
+    viewModelScope.launch {
+      meetings.value.forEach { meeting ->
+        if ((meeting.friendId == friendId && meeting.creatorId == currentUserID) ||
+            (meeting.friendId == currentUserID && meeting.creatorId == friendId)) {
+          deleteMeeting(meeting.meetingId)
+        }
+      }
+    }
+  }
 }

--- a/app/src/main/java/com/swent/suddenbump/ui/contact/ContactPage.kt
+++ b/app/src/main/java/com/swent/suddenbump/ui/contact/ContactPage.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.swent.suddenbump.model.meeting.MeetingViewModel
 import com.swent.suddenbump.model.user.UserViewModel
 import com.swent.suddenbump.ui.navigation.NavigationActions
 import com.swent.suddenbump.ui.navigation.Screen
@@ -46,7 +47,11 @@ import com.swent.suddenbump.ui.utils.UserProfileImage
 @OptIn(ExperimentalMaterial3Api::class)
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
-fun ContactScreen(navigationActions: NavigationActions, userViewModel: UserViewModel) {
+fun ContactScreen(
+    navigationActions: NavigationActions,
+    userViewModel: UserViewModel,
+    meetingViewModel: MeetingViewModel
+) {
   val user = userViewModel.getSelectedContact().collectAsState().value
   var showDialog by remember { mutableStateOf(false) }
 
@@ -58,6 +63,7 @@ fun ContactScreen(navigationActions: NavigationActions, userViewModel: UserViewM
   val isFriend = friendsList.any { it.uid == user.uid }
   val isFriendRequest = friendRequests.any { it.uid == user.uid }
   val isFriendRequestSent = sentFriendRequests.any { it.uid == user.uid }
+  val currentUser = userViewModel.getCurrentUser().collectAsState().value
 
   Scaffold(
       modifier = Modifier.fillMaxSize().background(Color.Black).testTag("contactScreen"),
@@ -98,6 +104,8 @@ fun ContactScreen(navigationActions: NavigationActions, userViewModel: UserViewM
                       modifier = Modifier.testTag("deleteFriendButton"),
                       onClick = {
                         expanded = false
+                        meetingViewModel.deleteAllMeetingsWithSpecificFriend(
+                            user.uid, currentUser.uid)
                         // Show a confirmation dialog or directly call deleteFriend
                         // For simplicity, directly call deleteFriend here:
                         userViewModel.deleteFriend(
@@ -149,20 +157,30 @@ fun ContactScreen(navigationActions: NavigationActions, userViewModel: UserViewM
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            Card(
-                modifier =
-                    Modifier.fillMaxWidth()
-                        .padding(horizontal = 50.dp, vertical = 10.dp)
-                        .testTag("phoneCard")) {
-                  Text(modifier = Modifier.padding(10.dp), text = "Phone: " + user.phoneNumber)
-                }
+            // Conditionally display the Phone Card only if users are friends
+            if (isFriend) {
+              Card(
+                  modifier =
+                      Modifier.fillMaxWidth()
+                          .padding(horizontal = 50.dp, vertical = 10.dp)
+                          .testTag("phoneCard")) {
+                    Text(
+                        modifier = Modifier.padding(10.dp),
+                        text = "Phone: ${user.phoneNumber}",
+                        color = Color.White)
+                  }
+            }
 
+            // Always display the Email Card
             Card(
                 modifier =
                     Modifier.fillMaxWidth()
                         .padding(horizontal = 50.dp, vertical = 10.dp)
                         .testTag("emailCard")) {
-                  Text(modifier = Modifier.padding(10.dp), text = "Email: " + user.emailAddress)
+                  Text(
+                      modifier = Modifier.padding(10.dp),
+                      text = "Email: ${user.emailAddress}",
+                      color = Color.White)
                 }
           }
 


### PR DESCRIPTION
- Added a function to allow the user to delete all the meetings related to him and the user friend he is removing.
- Now contact screen shows phone number to user friends only, not everyone.